### PR TITLE
ENH: vectorize for loops with `numpy`

### DIFF
--- a/lecture09.ipynb
+++ b/lecture09.ipynb
@@ -36,9 +36,6 @@
    },
    "outputs": [],
    "source": [
-    "import math\n",
-    "import random\n",
-    "\n",
     "import gdown\n",
     "import matplotlib\n",
     "import matplotlib.cm as cm\n",
@@ -57,7 +54,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "## Estimator Definition"
    ]
@@ -294,7 +294,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Selected properties of the population M1-> Mean S1**2 is the variance\n",
@@ -308,14 +310,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random.seed(42)\n",
-    "students = 5\n",
-    "sample = []\n",
-    "for i in range(students):\n",
-    "    sample.append(random.gauss(M1, S1))\n",
-    "\n",
-    "sample = np.array(sample)\n",
-    "print(sample)"
+    "RNG = np.random.default_rng(42)\n",
+    "n_students = 5\n",
+    "sample = RNG.normal(M1, S1, size=n_students)\n",
+    "sample"
    ]
   },
   {
@@ -324,22 +322,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def variance1(array, m):\n",
-    "    som = 0\n",
-    "    l = len(array)\n",
-    "    for i in range(l):\n",
-    "        som = som + (array[i] - m) ** 2 / l\n",
-    "\n",
-    "    return som\n",
+    "def variance1(array):\n",
+    "    abs_diff = np.abs(array - array.mean())\n",
+    "    return np.sum(abs_diff**2) / array.size\n",
     "\n",
     "\n",
-    "def variance2(array, m):\n",
-    "    som = 0\n",
-    "    l = len(array)\n",
-    "    for i in range(l):\n",
-    "        som = som + (array[i] - m) ** 2 / (l - 1)\n",
-    "\n",
-    "    return som"
+    "def variance2(array):\n",
+    "    abs_diff = np.abs(array - array.mean())\n",
+    "    return np.sum(abs_diff**2) / (array.size - 1)"
    ]
   },
   {
@@ -348,11 +338,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "av = sample.mean()\n",
-    "\n",
-    "print(\"The mean of the sample is =\", av)\n",
-    "print(\"The Variance (with bias) is=\", variance1(sample, av))\n",
-    "print(\"The Variance (without bias) is=\", variance2(sample, av))"
+    "print(\"The mean of the sample is\", sample.mean())\n",
+    "print(\"The variance (with bias) is\", variance1(sample))\n",
+    "print(\"The variance (without bias) is\", variance2(sample))"
    ]
   },
   {
@@ -384,7 +372,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lets redo our previous example by repeating our previous test 10000 times. Each time we calculate the mean and variances (using both definitions we have seen)."
+    "Lets redo our previous example by repeating our previous test 100.000 times. Each time we calculate the mean and variances (using both definitions we have seen)."
    ]
   },
   {
@@ -393,33 +381,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "NNN = 100000\n",
+    "n_repeats = 100_000\n",
     "\n",
-    "ave = []\n",
-    "var1 = []\n",
-    "var2 = []\n",
+    "averages = []\n",
+    "variance_biased = []\n",
+    "variance_unbiased = []\n",
+    "for _ in range(n_repeats):\n",
+    "    sample = RNG.normal(M1, S1, size=n_students)\n",
+    "    averages.append(sample.mean())\n",
+    "    variance_biased.append(variance1(sample))\n",
+    "    variance_unbiased.append(variance2(sample))\n",
     "\n",
-    "for j in range(NNN):\n",
-    "    students = 5\n",
-    "    sample = []\n",
-    "    for i in range(students):\n",
-    "        sample.append(random.gauss(M1, S1))\n",
-    "\n",
-    "    sample = np.array(sample)\n",
-    "    av = sample.mean()\n",
-    "    ave.append(av)\n",
-    "    var1.append(variance1(sample, av))\n",
-    "    var2.append(variance2(sample, av))"
+    "averages = np.array(averages)\n",
+    "variance_biased = np.array(variance_biased)\n",
+    "variance_unbiased = np.array(variance_unbiased)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# plotting a graph\n",
-    "plt.hist(ave)\n",
+    "plt.hist(averages)\n",
     "plt.ylabel(\"Counts\")\n",
     "plt.axvline(M1, color=\"k\", linestyle=\"dashed\", linewidth=1)\n",
     "plt.xlabel(\"Average\")\n",
@@ -430,33 +419,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The mean (as expected) works very well to estimate the 'mean' of the population.\n",
-    "what about the 2 definitions of variance?\n",
-    "\n"
+    "The mean (as expected) works very well to estimate the 'mean' of the population. What about the 2 definitions of variance?"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "plt.hist(var1, bins=30)\n",
-    "plt.hist(var2, bins=30, alpha=0.6)\n",
+    "plt.hist(variance_biased, bins=30)\n",
+    "plt.hist(variance_unbiased, bins=30, alpha=0.6)\n",
     "plt.ylabel(\"Counts\")\n",
     "plt.axvline(S1**2, color=\"k\", linestyle=\"dashed\", linewidth=1)\n",
     "plt.xlabel(\"Average\")\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "var1 = np.array(var1)\n",
-    "var2 = np.array(var2)"
    ]
   },
   {
@@ -472,8 +454,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"The average value of the variance (biased)is \", var1.mean())\n",
-    "print(\"The average value of the variance (unbiased)is \", var2.mean())"
+    "print(\"The average value of the biased variance is\", variance_biased.mean())\n",
+    "print(\"The average value of the unbiased variance is\", variance_unbiased.mean())"
    ]
   },
   {
@@ -485,7 +467,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "## Method of Moments (MoM)"
    ]
@@ -648,7 +633,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "## Maximum Likelihood"
    ]
@@ -687,11 +675,12 @@
    "metadata": {
     "jupyter": {
      "source_hidden": true
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
-    "print(\"the probability is=\", norm.pdf(5, 5, 3))"
+    "print(\"The probability is\", norm.pdf(5, 5, 3))"
    ]
   },
   {
@@ -704,10 +693,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "print(\"the probability is=\", norm.pdf(5, 7, 3))"
+    "print(\"The probability is\", norm.pdf(5, 7, 3))"
    ]
   },
   {
@@ -732,7 +726,7 @@
    "source": [
     "data = [4, 5, 7, 8, 8, 9, 10, 5, 2, 3, 5, 4, 8, 9]\n",
     "\n",
-    "x = np.linspace(0, 20, 100)\n",
+    "x = np.linspace(0, 20, num=100)\n",
     "plt.subplot(2, 1, 1)\n",
     "plt.plot(x, stats.norm.pdf(x, 5, 3), label=\"N(5,3)\")\n",
     "plt.plot(x, stats.norm.pdf(x, 7, 3), label=\"N(7,3)\")\n",
@@ -816,16 +810,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = [4, 5, 7, 8, 8, 9, 10, 5, 2, 3, 5, 4, 8, 9]\n",
+    "data = np.array([4, 5, 7, 8, 8, 9, 10, 5, 2, 3, 5, 4, 8, 9])\n",
+    "std = 3\n",
     "\n",
     "\n",
-    "def likelihood(mu, x):\n",
-    "    # Compare the likelihood of the random samples to the two distributions\n",
-    "    ll = 0\n",
-    "    sd = 3\n",
-    "    for i in x:\n",
-    "        ll += np.log(norm.pdf(i, mu, sd))\n",
-    "    return ll"
+    "@np.vectorize\n",
+    "def likelihood(mu) -> float:\n",
+    "    return np.sum(np.log(norm.pdf(data, mu, std)))"
    ]
   },
   {
@@ -841,10 +832,10 @@
    },
    "outputs": [],
    "source": [
-    "mu = np.linspace(0, 12, 100)\n",
-    "fun = likelihood(mu, data)\n",
+    "mu = np.linspace(0, 12, num=100)\n",
+    "ll = likelihood(mu)\n",
     "\n",
-    "plt.plot(mu, fun, label=\"Likelihood\")\n",
+    "plt.plot(mu, ll, label=\"Likelihood\")\n",
     "plt.xlabel(\"mu\")\n",
     "plt.legend()\n",
     "plt.show()"
@@ -864,23 +855,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Compare the likelihood of the random samples to the two # distributions\n",
-    "data = [4, 5, 7, 8, 8, 9, 10, 5, 2, 3, 5, 4, 8, 9]\n",
-    "\n",
-    "\n",
-    "def llog(mu, x):\n",
-    "    ll = 0\n",
-    "    sd = 3\n",
-    "    for i in x:\n",
-    "        ll += -np.log(norm.pdf(i, mu, 3))\n",
-    "    return ll"
+    "@np.vectorize\n",
+    "def likelihood(mu) -> float:\n",
+    "    return -np.sum(np.log(norm.pdf(data, mu, std)))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So the routine found that the best value for mu is. actually 6.21 !!!"
+    "So the routine found that the best value for `mu` is. actually 6.21 !!!"
    ]
   },
   {
@@ -889,7 +873,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "opt.fmin(llog, 1, args=(data,))"
+    "opt.fmin(func=likelihood, x0=1)"
    ]
   },
   {
@@ -1037,17 +1021,7 @@
     "P(x;\\mu,\\sigma)=\\frac{1}{\\sqrt{2\\pi \\sigma^2}}e^{-\\frac{(x-\\mu)^2}{2\\sigma^2}}\n",
     "\\end{equation}\n",
     "\n",
-    "Now assume that we want to esimtate both $\\mu$ and $\\sigma$ from a given data-set"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Same data as before\n",
-    "data = [4, 5, 7, 8, 8, 9, 10, 5, 2, 3, 5, 4, 8, 9]"
+    "Now assume that we want to esimtate both $\\mu$ and $\\sigma$ from a the same data set as we used before."
    ]
   },
   {
@@ -1063,12 +1037,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def llog2(mu, sigma, x):\n",
-    "    ll = 0\n",
-    "    sd = sigma\n",
-    "    for i in x:\n",
-    "        ll += -np.log(norm.pdf(i, mu, sd))\n",
-    "    return ll"
+    "@np.vectorize\n",
+    "def likelihood2(mu, sigma) -> float:\n",
+    "    return -np.sum(np.log(norm.pdf(data, mu, sigma)))"
    ]
   },
   {
@@ -1077,11 +1048,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mu = np.linspace(1, 10, 100)\n",
-    "sigma = np.linspace(1, 4, 100)\n",
+    "mu = np.linspace(1, 10, num=100)\n",
+    "sigma = np.linspace(1, 4, num=100)\n",
     "\n",
-    "X, Y = np.meshgrid(mu, sigma)\n",
-    "Z = llog2(X, Y, data)"
+    "a_grid, b_grid = np.meshgrid(mu, sigma)\n",
+    "Z = likelihood2(a_grid, b_grid)"
    ]
   },
   {
@@ -1099,12 +1070,11 @@
    "source": [
     "fig, ax = plt.subplots(constrained_layout=True)\n",
     "levels = MaxNLocator(nbins=55).tick_values(Z.min(), Z.max())\n",
-    "cmap = plt.get_cmap(\"RdGy\")\n",
-    "normB = BoundaryNorm(levels, ncolors=cmap.N, clip=True)\n",
-    "pc = ax.contourf(X, Y, Z, cmap=cmap, norm=normB)\n",
-    "CS = plt.contour(X, Y, Z, 100, linewidths=0.5, colors=\"k\")\n",
-    "cbar = fig.colorbar(CS)\n",
-    "cbar.ax.set_ylabel(\"LL\")\n",
+    "n_levels = 100\n",
+    "plt.contour(a_grid, b_grid, Z, n_levels, linewidths=0.5, colors=\"k\")\n",
+    "mesh = ax.contourf(a_grid, b_grid, Z, n_levels, cmap=plt.cm.RdGy)\n",
+    "cbar = fig.colorbar(mesh)\n",
+    "cbar.ax.set_ylabel(\"Log likelihood\")\n",
     "\n",
     "plt.ylabel(\"$\\sigma$\")\n",
     "plt.xlabel(\"$\\mu$\")\n",
@@ -1118,13 +1088,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def llog3(params):\n",
-    "    ll = 0\n",
-    "    a, b = params\n",
-    "    data = [4, 5, 7, 8, 8, 9, 10, 5, 2, 3, 5, 4, 8, 9]\n",
-    "    for i in data:\n",
-    "        ll += -np.log(norm.pdf(i, a, b))\n",
-    "    return ll"
+    "def optimizable_nll(params) -> float:\n",
+    "    mu, sigma = params\n",
+    "    return -np.sum(np.log(norm.pdf(data, mu, sigma)))"
    ]
   },
   {
@@ -1133,15 +1099,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x0 = [6, 3]\n",
-    "\n",
-    "res = opt.minimize(llog3, x0)\n",
-    "print(res.x)"
+    "res = opt.minimize(optimizable_nll, x0=(6, 3))\n",
+    "res"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "## Properties of the ML estimator"
    ]
@@ -1366,14 +1333,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Fitting data – Method of least squares"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "### Introduction"
    ]
@@ -1427,7 +1399,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "### χ² PDF"
    ]
@@ -1487,7 +1462,7 @@
     "k_values = [1, 2, 5, 7]\n",
     "linestyles = [\"-\", \"--\", \":\", \"-.\"]\n",
     "mu = 0\n",
-    "x = np.linspace(-1, 20, 1000)\n",
+    "x = np.linspace(-1, 20, num=1_000)\n",
     "# ------------------------------------------------------------"
    ]
   },
@@ -1519,7 +1494,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "### Linear least squares"
    ]
@@ -1600,7 +1578,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Choose the \"true\" parameters.\n",
@@ -1613,10 +1596,11 @@
     "y = m_true * x + c_true\n",
     "y += np.random.randn(N)\n",
     "plt.errorbar(x, y, fmt=\".k\", capsize=0)\n",
-    "x0 = np.linspace(0, 10, 500)\n",
+    "starting_values = np.linspace(0, 10, num=500)\n",
     "plt.xlim(0, 10)\n",
     "plt.xlabel(\"x\")\n",
-    "plt.ylabel(\"y\")"
+    "plt.ylabel(\"y\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -1648,22 +1632,38 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "plt.errorbar(x, y, fmt=\".k\", capsize=0)\n",
-    "plt.plot(x0, m_true * x0 + c_true, \"k\", alpha=0.3, lw=3, label=\"truth\")\n",
-    "plt.plot(x0, mfit * x0 + cfit, \"r\", lw=3, label=\"LS\")\n",
+    "plt.plot(\n",
+    "    starting_values,\n",
+    "    m_true * starting_values + c_true,\n",
+    "    \"k\",\n",
+    "    alpha=0.3,\n",
+    "    lw=3,\n",
+    "    label=\"truth\",\n",
+    ")\n",
+    "plt.plot(starting_values, mfit * starting_values + cfit, \"r\", lw=3, label=\"LS\")\n",
     "plt.xlabel(\"x\")\n",
     "plt.ylabel(\"y\")\n",
     "plt.legend(fontsize=14)\n",
-    "plt.show()\n",
-    "# plt.xlim(0, 10)"
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "#### Uncertainties and covariances for straight-line fit"
    ]
@@ -1790,7 +1790,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "### Linear models"
    ]
@@ -1921,7 +1924,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "### Non-linear model"
    ]
@@ -1944,9 +1950,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": [
-     "hide-input"
-    ]
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1955,13 +1959,26 @@
     "\n",
     "\n",
     "np.random.seed(123)\n",
-    "x = np.linspace(0, 20, 50)\n",
-    "\n",
+    "n_points = 50\n",
+    "x = np.linspace(0, 20, num=n_points)\n",
     "y = (np.sin(x / 3) + np.random.normal(np.sin(x / 3), 0.2)) / 2\n",
-    "ery = []\n",
-    "for i in range(len(x)):\n",
-    "    ery.append(np.random.normal(0.1, 0.02))\n",
-    "plt.errorbar(x, y, ery, ls=\"\", marker=\".\")\n",
+    "y_error = np.random.normal(0.1, 0.02, size=n_points)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "plt.errorbar(x, y, y_error, ls=\"\", marker=\".\")\n",
     "plt.xlabel(\"x\")\n",
     "plt.ylabel(\"Data\")\n",
     "plt.show()"
@@ -1975,8 +1992,7 @@
    "source": [
     "gmodel = Model(func)\n",
     "result = gmodel.fit(y, x=x, a=1)\n",
-    "\n",
-    "print(result.fit_report())"
+    "result"
    ]
   },
   {
@@ -1985,17 +2001,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def chi2Unc(x, y, ey, a):\n",
+    "@np.vectorize\n",
+    "def chi2_uncertainty(a):\n",
     "    z = func(x, a)\n",
-    "    return sum(((y - z) / ey) ** 2)\n",
+    "    return np.sum(((y - z) / y_error) ** 2)\n",
     "\n",
     "\n",
     "av = np.linspace(0.1, 4, 100)\n",
-    "\n",
-    "z = np.zeros(len(av))\n",
-    "for i in range(len(av)):\n",
-    "    a = av[i]\n",
-    "    z[i] = chi2Unc(x, y, ery, a)"
+    "z = chi2_uncertainty(av)"
    ]
   },
   {
@@ -2023,13 +2036,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eryrec = []\n",
-    "for i in range(len(x)):\n",
-    "    eryrec.append(1 / ery[i])\n",
-    "\n",
     "gmodel = Model(func)\n",
-    "result = gmodel.fit(y, a=1.2, x=x, weights=eryrec)\n",
-    "print(result.fit_report())"
+    "result = gmodel.fit(y, a=1.2, x=x, weights=1 / y_error)\n",
+    "result"
    ]
   },
   {
@@ -2045,7 +2054,7 @@
    },
    "outputs": [],
    "source": [
-    "plt.errorbar(x, y, ery, ls=\"\", marker=\".\")\n",
+    "plt.errorbar(x, y, y_error, ls=\"\", marker=\".\")\n",
     "plt.plot(x, result.best_fit, \"r-\", label=\"best fit\")\n",
     "plt.legend(loc=\"best\")\n",
     "plt.xlabel(\"x\")\n",
@@ -2060,8 +2069,8 @@
    "outputs": [],
    "source": [
     "gmodel = Model(func)\n",
-    "result = gmodel.fit(y, a=0.2, x=x, weights=eryrec)\n",
-    "print(result.fit_report())"
+    "result = gmodel.fit(y, a=0.2, x=x, weights=1 / y_error)\n",
+    "result"
    ]
   },
   {
@@ -2077,7 +2086,7 @@
    },
    "outputs": [],
    "source": [
-    "plt.errorbar(x, y, ery, ls=\"\", marker=\".\")\n",
+    "plt.errorbar(x, y, y_error, ls=\"\", marker=\".\")\n",
     "plt.plot(x, result.best_fit, \"r-\", label=\"best fit\")\n",
     "plt.legend(loc=\"best\")\n",
     "plt.xlabel(\"x\")\n",
@@ -2092,17 +2101,20 @@
    "outputs": [],
    "source": [
     "k = len(x) - 1\n",
-    "print(\"number of degrees of freedom=\", k)\n",
+    "print(\"Number of degrees of freedom:\", k)\n",
     "\n",
-    "r1 = np.sqrt(2 * chi2Unc(x, y, ery, 1.41084859)) / np.sqrt(2 * k - 1)\n",
-    "r2 = np.sqrt(2 * chi2Unc(x, y, ery, 0.33495704)) / np.sqrt(2 * k - 1)\n",
+    "r1 = np.sqrt(2 * chi2_uncertainty(a=1.41084859)) / np.sqrt(2 * k - 1)\n",
+    "r2 = np.sqrt(2 * chi2_uncertainty(a=0.33495704)) / np.sqrt(2 * k - 1)\n",
     "\n",
     "print(r1, r2)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "### Residuals"
    ]
@@ -2153,7 +2165,7 @@
    },
    "outputs": [],
    "source": [
-    "residualUnc = (y - result.best_fit) / ery\n",
+    "residualUnc = (y - result.best_fit) / y_error\n",
     "# plt.plot(x, residual, 'bo', label='Residuals')\n",
     "fig, ax = plt.subplots()\n",
     "ax.stem(x, residualUnc, markerfmt=\" \", use_line_collection=True)\n",
@@ -2242,51 +2254,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "np.random.seed(32)\n",
     "\n",
-    "x = np.linspace(1, 10, 20)\n",
-    "y = np.linspace(0, 0, 20)\n",
-    "erry = []\n",
-    "for i in range(len(x)):\n",
-    "    y[i] = np.random.poisson((13 * np.exp(-x[i] / 3)))\n",
-    "    if y[i] < 0:\n",
-    "        y[i] = 0\n",
-    "y = y.astype(int)\n",
-    "datax = []\n",
-    "datay = []\n",
-    "dataey = []\n",
-    "eryrec = []\n",
-    "for i in range(len(x)):\n",
-    "    if y[i] > 0:\n",
-    "        datax.append(x[i])\n",
-    "        datay.append(y[i])\n",
-    "        dataey.append(np.sqrt(y[i]))\n",
-    "        eryrec.append(1.0 / np.sqrt(y[i]))"
+    "sample_size = 20\n",
+    "x = np.linspace(1, 10, num=sample_size)\n",
+    "y = np.vectorize(lambda z: np.random.poisson(13 * np.exp(-z / 3)))(x)\n",
+    "y"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "datax = np.array(datax)\n",
-    "datay = np.array(datay)\n",
-    "dataey = np.array(dataey)\n",
-    "eryrec = np.array(eryrec)"
+    "data_x = x[y > 0]\n",
+    "data_y = y[y > 0]\n",
+    "data_y_err = np.sqrt(data_y)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# We generate noisy data on integer values of x to mimick the idea of bins and low-statistics...\n",
-    "plt.errorbar(datax, datay, dataey, ls=\"\", marker=\".\")\n",
+    "plt.errorbar(data_x, data_y, data_y_err, ls=\"\", marker=\".\")\n",
     "# plt.plot(x,y,'o',label=\"data\")\n",
     "plt.xlabel(\"t\")\n",
     "plt.ylabel(\"counts\")\n",
@@ -2303,7 +2306,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def func(x, a, b):\n",
@@ -2313,24 +2318,32 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "gmodel = Model(func)\n",
     "gmodel.nan_policy = \"propagate\"\n",
-    "result = gmodel.fit(datay, x=datax, weights=eryrec, a=12, b=-0.3)\n",
-    "\n",
-    "print(result.fit_report())"
+    "result = gmodel.fit(data_y, x=data_x, weights=1 / data_y_err, a=12, b=-0.3)\n",
+    "result"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
-    "plt.errorbar(datax, datay, dataey, ls=\"\", marker=\".\")\n",
-    "plt.plot(datax, result.best_fit, \"-\", label=\"Fit\")\n",
+    "plt.errorbar(data_x, data_y, data_y_err, ls=\"\", marker=\".\")\n",
+    "plt.plot(data_x, result.best_fit, \"-\", label=\"Fit\")\n",
     "plt.legend()\n",
     "plt.xlabel(\"t\")\n",
     "plt.ylabel(\"counts\")\n",
@@ -2347,43 +2360,50 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "def chi2(aaa, bbb):\n",
-    "    ll = 0\n",
-    "    for i in range(len(datax)):\n",
-    "        ll += ((datay[i] - func(datax[i], aaa, bbb)) ** 2) * eryrec[i] ** 2\n",
-    "    # print(datay[i])\n",
-    "    return ll"
+    "def chi2(a, b):\n",
+    "    return sum(\n",
+    "        ((y - func(x, a, b)) ** 2) / (ey**2)\n",
+    "        for x, y, ey in zip(data_x, data_y, data_y_err)\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "Ax = np.linspace(0, 16, 500)\n",
-    "Bx = np.linspace(-0.7, -0.15, 500)\n",
-    "\n",
-    "Axgrid, Bxgrid = np.meshgrid(Ax, Bx)\n",
-    "Zgrid = chi2(Axgrid, Bxgrid)"
+    "grid_size = 500\n",
+    "a_grid, b_grid = np.meshgrid(\n",
+    "    np.linspace(0, 16, grid_size),\n",
+    "    np.linspace(-0.7, -0.15, grid_size),\n",
+    ")\n",
+    "Z = chi2(a_grid, b_grid)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(constrained_layout=True)\n",
-    "levels = MaxNLocator(nbins=55).tick_values(Zgrid.min(), Zgrid.max())\n",
-    "cmap = plt.get_cmap(\"PiYG\")\n",
-    "normB = BoundaryNorm(levels, ncolors=cmap.N, clip=True)\n",
-    "pc = ax.contourf(Axgrid, Bxgrid, Zgrid, cmap=cmap, norm=normB)\n",
-    "CS = plt.contour(Axgrid, Bxgrid, Zgrid, 100, linewidths=0.5, colors=\"k\")\n",
-    "\n",
+    "n_levels = 100\n",
+    "mesh = ax.contourf(a_grid, b_grid, Z, n_levels, cmap=plt.cm.PiYG)\n",
+    "plt.contour(a_grid, b_grid, Z, n_levels, linewidths=0.5, colors=\"k\")\n",
+    "fig.colorbar(mesh)\n",
     "plt.ylabel(\"-tau\")\n",
     "plt.xlabel(\"A\")\n",
     "ax.grid()\n",
@@ -2420,46 +2440,53 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def like(param):\n",
-    "    aaa, bbb = param\n",
-    "    ll = 0\n",
-    "    for i in range(len(datax)):\n",
-    "        ll += 2 * (\n",
-    "            func(datax[i], aaa, bbb) - datay[i] * np.log(func(datax[i], aaa, bbb))\n",
-    "        )\n",
-    "    return ll"
+    "    a, b = param\n",
+    "    return sum(\n",
+    "        2 * (func(x, a, b) - y * np.log(func(x, a, b))) for x, y in zip(data_x, data_y)\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "Ax = np.linspace(0, 16, 500)\n",
-    "Bx = np.linspace(-0.7, -0.15, 500)\n",
-    "\n",
-    "Axgrid, Bxgrid = np.meshgrid(Ax, Bx)\n",
-    "paramz = [Axgrid, Bxgrid]\n",
-    "Zgrid = like(paramz)"
+    "grid_size = 500\n",
+    "a_grid, b_grid = np.meshgrid(\n",
+    "    np.linspace(0, 16, grid_size),\n",
+    "    np.linspace(-0.7, -0.15, grid_size),\n",
+    ")\n",
+    "paramz = [a_grid, b_grid]\n",
+    "Z = like(paramz)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(constrained_layout=True)\n",
-    "levels = MaxNLocator(nbins=55).tick_values(Zgrid.min(), Zgrid.max())\n",
-    "cmap = plt.get_cmap(\"PiYG\")\n",
-    "normB = BoundaryNorm(levels, ncolors=cmap.N, clip=True)\n",
-    "pc = ax.contourf(Axgrid, Bxgrid, Zgrid, cmap=cmap, norm=normB)\n",
-    "CS = plt.contour(Axgrid, Bxgrid, Zgrid, 100, linewidths=0.5, colors=\"k\")\n",
-    "\n",
+    "n_levels = 100\n",
+    "mesh = ax.contourf(a_grid, b_grid, Z, n_levels, cmap=plt.cm.PiYG)\n",
+    "plt.contour(a_grid, b_grid, Z, n_levels, linewidths=0.5, colors=\"k\")\n",
+    "fig.colorbar(mesh, ax=ax)\n",
     "plt.ylabel(\"-tau\")\n",
     "plt.xlabel(\"$A$\")\n",
     "ax.grid()\n",
@@ -2469,7 +2496,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "p0 = [10, -0.3]\n",
@@ -2486,12 +2515,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
-    "plt.errorbar(datax, datay, dataey, ls=\"\", marker=\".\")\n",
-    "plt.plot(datax, result.best_fit, \"-\", label=\"Fit Gaussian\")\n",
-    "plt.plot(datax, func(datax, 10.35008492, -0.26507234), \"-\", label=\"Fit Poisson\")\n",
+    "plt.errorbar(data_x, data_y, data_y_err, ls=\"\", marker=\".\")\n",
+    "plt.plot(data_x, result.best_fit, \"-\", label=\"Fit Gaussian\")\n",
+    "plt.plot(data_x, func(data_x, 10.35008492, -0.26507234), \"-\", label=\"Fit Poisson\")\n",
     "plt.legend()\n",
     "plt.xlabel(\"t\")\n",
     "plt.ylabel(\"counts\")\n",
@@ -2600,7 +2636,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Extended Max Likelihood"
    ]
@@ -2713,12 +2751,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
-    "tags": [
-     "hide-input"
-    ]
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -2728,13 +2761,24 @@
     "    md5=\"fcf1a7ff3bdeece6154d1fb1ca03ef97\",\n",
     "    quiet=True,\n",
     ")\n",
-    "f = open(output_path)\n",
-    "values = []\n",
-    "for line in f.readlines():\n",
-    "    values.append(float(line))\n",
-    "f.close()\n",
-    "\n",
-    "bins = int(math.sqrt(len(values))) - 1\n",
+    "with open(output_path) as f:\n",
+    "    values = [float(line) for line in f.readlines()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "bins = int(np.sqrt(len(values))) - 1\n",
     "minim = min(values)\n",
     "maxim = max(values)\n",
     "print(\"Number of bins:\", bins, \" with bounds: \", minim, \" and \", maxim)\n",
@@ -2759,28 +2803,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def llog(params):\n",
-    "    ll = 0\n",
     "    s, mu, sigma = params\n",
-    "    n = len(values)\n",
-    "    for i in values:\n",
-    "        ll += -np.log(s * norm.pdf(i, mu, sigma))\n",
-    "    ll = ll + s\n",
-    "    return ll"
+    "    return s - sum(np.log(s * norm.pdf(x, mu, sigma)) for x in values)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "x0 = [2000, 1.12, 0.01]\n",
-    "res = opt.minimize(llog, x0)\n",
-    "print(res.x)"
+    "starting_values = [2000, 1.12, 0.01]\n",
+    "res = opt.minimize(llog, starting_values)\n",
+    "res"
    ]
   },
   {
@@ -2793,12 +2836,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "## We can plot the Gaussian function on top of our histogram. We need to scale the Gaussian function\n",
     "## to our bin width to properly vizualise it.\n",
-    "x = np.linspace(1.05, 1.20, 1000)\n",
+    "x = np.linspace(1.05, 1.20, num=1_000)\n",
     "\n",
     "\n",
     "def Gaus(x, params):\n",

--- a/lecture12a-gammap-solution.ipynb
+++ b/lecture12a-gammap-solution.ipynb
@@ -37,39 +37,56 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "mystnb": {
+     "code_prompt_show": "Import Python libraries"
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
    "outputs": [],
    "source": [
+    "import gdown\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from pylorentz import Momentum4"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "mystnb": {
      "code_prompt_show": "Download data"
     },
     "tags": [
-     "hide-input"
+     "hide-input",
+     "full-width"
     ]
    },
    "outputs": [],
    "source": [
-    "import gdown\n",
-    "\n",
     "output_path = gdown.cached_download(\n",
     "    url=\"https://drive.google.com/uc?id=1qiYjPbR5nx3_Sw7MXuUKhNAUpkXPoxYh\",\n",
     "    path=\"data/lecture6-gammap-data.csv\",\n",
     "    md5=\"38cf5bf915318df756a21a82ad9e4afa\",\n",
     "    quiet=True,\n",
     ")\n",
-    "data = pd.read_csv(output_path)"
+    "data = pd.read_csv(output_path)\n",
+    "data.columns = data.columns.str.strip()\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> The columns headers present some trailing blanks, that must be dropped to be able to use correctly the DataFormat structure (if not, they deliver an error message). To do so, the `str.strip()` function must be used beforehand to reformat the column shape."
    ]
   },
   {
@@ -80,34 +97,21 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
-    "tags": [
-     "full-width"
-    ]
+    "tags": []
    },
-   "outputs": [],
    "source": [
-    "data.head()"
+    "## Invariant mass distributions"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "The columns headers present some trailing blanks, that must be dropped to be able to use correctly the DataFormat structure (if not, they deliver an error message). To do so, the *str.strip()* function must be used beforehand to reformat the column shape.\n",
-    "In the following commands in the cell, columns are shown, overall with the data.columns command, and per single variable (like *data.p2x*). If the format is correct, no error should appear."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data.columns = data.columns.str.strip()\n",
-    "data.p2x"
+    "### Measured data"
    ]
   },
   {
@@ -123,27 +127,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "invariant_massSquared12 = (\n",
+    "inv_mass_squared_12 = (\n",
     "    (data.E1 + data.E2) ** 2\n",
     "    - (data.p1x + data.p2x) ** 2\n",
     "    - (data.p1y + data.p2y) ** 2\n",
     "    - (data.p1z + data.p2z) ** 2\n",
     ")\n",
-    "invariant_mass12 = np.sqrt(invariant_massSquared12)\n",
-    "invariant_massSquared13 = (\n",
+    "inv_mass_squared_13 = (\n",
     "    (data.E1 + data.E3) ** 2\n",
     "    - (data.p1x + data.p3x) ** 2\n",
     "    - (data.p1y + data.p3y) ** 2\n",
     "    - (data.p1z + data.p3z) ** 2\n",
     ")\n",
-    "invariant_mass13 = np.sqrt(invariant_massSquared13)\n",
-    "invariant_massSquared23 = (\n",
+    "inv_mass_squared_23 = (\n",
     "    (data.E3 + data.E2) ** 2\n",
     "    - (data.p3x + data.p2x) ** 2\n",
     "    - (data.p3y + data.p2y) ** 2\n",
     "    - (data.p3z + data.p2z) ** 2\n",
     ")\n",
-    "invariant_mass23 = np.sqrt(invariant_massSquared23)"
+    "invariant_mass_12 = np.sqrt(inv_mass_squared_12)\n",
+    "invariant_mass_13 = np.sqrt(inv_mass_squared_13)\n",
+    "invariant_mass_23 = np.sqrt(inv_mass_squared_23)"
    ]
   },
   {
@@ -194,7 +198,7 @@
    "outputs": [],
    "source": [
     "# plot the histogram pi+pi-\n",
-    "plt.hist(invariant_mass12, bins=200, range=(0.2, 1.2))\n",
+    "plt.hist(invariant_mass_12, bins=200, range=(0.2, 1.2))\n",
     "plt.xlabel(\"Invariant mass [GeV]\")\n",
     "plt.ylabel(\"Entries/(5 MeV)\")\n",
     "plt.title(\"The histogram of the invariant mass of $\\pi^+$ and $\\pi^-$ \\n\")\n",
@@ -215,7 +219,7 @@
    "outputs": [],
    "source": [
     "# plot the histogram pi+proton\n",
-    "plt.hist(invariant_mass13, bins=200, color=\"tomato\", range=(1.0, 2.0))\n",
+    "plt.hist(invariant_mass_13, bins=200, color=\"tomato\", range=(1.0, 2.0))\n",
     "plt.xlabel(\"Invariant mass [GeV]\")\n",
     "plt.ylabel(\"Entries/(5 MeV)\")\n",
     "plt.title(\"The histogram of the invariant mass of $\\pi^+$ and proton  \\n\")\n",
@@ -236,7 +240,7 @@
    "outputs": [],
    "source": [
     "# plot the histogram pi-proton\n",
-    "plt.hist(invariant_mass23, bins=200, color=\"darkmagenta\", range=(1.0, 2.0))\n",
+    "plt.hist(invariant_mass_23, bins=200, color=\"darkmagenta\", range=(1.0, 2.0))\n",
     "plt.xlabel(\"Invariant mass [GeV]\")\n",
     "plt.ylabel(\"Entries/(5 MeV)\")\n",
     "plt.title(\"The histogram of the invariant mass of $\\pi^-$ and proton \\n\")\n",
@@ -263,8 +267,8 @@
    },
    "outputs": [],
    "source": [
-    "plt.hist(invariant_mass13, bins=200, color=\"tomato\", range=(1.0, 2.0))\n",
-    "plt.hist(invariant_mass23, bins=200, color=\"darkmagenta\", alpha=0.4, range=(1.0, 2.0))\n",
+    "plt.hist(invariant_mass_13, bins=200, color=\"tomato\", range=(1.0, 2.0))\n",
+    "plt.hist(invariant_mass_23, bins=200, color=\"darkmagenta\", alpha=0.4, range=(1.0, 2.0))\n",
     "plt.xlabel(\"Invariant mass [GeV]\")\n",
     "plt.ylabel(\"Entries/(5 MeV)\")\n",
     "plt.show()"
@@ -292,8 +296,8 @@
    "source": [
     "fig, ax = plt.subplots(1, 2, tight_layout=True, figsize=(7, 4))\n",
     "ax[0].hist2d(\n",
-    "    invariant_massSquared13,\n",
-    "    invariant_massSquared12,\n",
+    "    inv_mass_squared_13,\n",
+    "    inv_mass_squared_12,\n",
     "    bins=200,\n",
     "    range=[[1.0, 3], [0.0, 0.8]],\n",
     "    cmap=\"jet\",\n",
@@ -301,8 +305,8 @@
     "ax[0].set_xlabel(\"i.m.$^2(\\pi^+p$) [GeV$^2$]\")\n",
     "ax[0].set_ylabel(\"i.m.$^2(\\pi^+\\pi^-$) [GeV$^2$]\")\n",
     "ax[1].hist2d(\n",
-    "    invariant_massSquared13,\n",
-    "    invariant_massSquared23,\n",
+    "    inv_mass_squared_13,\n",
+    "    inv_mass_squared_23,\n",
     "    bins=200,\n",
     "    range=[[1.0, 3], [1.0, 3.0]],\n",
     "    cmap=\"jet\",\n",
@@ -310,6 +314,15 @@
     "ax[1].set_xlabel(\"i.m.$^2(\\pi^+p$) [GeV$^2$]\")\n",
     "ax[1].set_ylabel(\"i.m.$^2(\\pi^-p$) [GeV$^2$]\")\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Monte Carlo data"
    ]
   },
   {
@@ -352,19 +365,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "invariant_massSquared12mc = (\n",
+    "inv_mass_squared_12_mc = (\n",
     "    (mc.E1 + mc.E2) ** 2\n",
     "    - (mc.p1x + mc.p2x) ** 2\n",
     "    - (mc.p1y + mc.p2y) ** 2\n",
     "    - (mc.p1z + mc.p2z) ** 2\n",
     ")\n",
-    "invariant_massSquared13mc = (\n",
+    "inv_mass_squared_13_mc = (\n",
     "    (mc.E1 + mc.E3) ** 2\n",
     "    - (mc.p1x + mc.p3x) ** 2\n",
     "    - (mc.p1y + mc.p3y) ** 2\n",
     "    - (mc.p1z + mc.p3z) ** 2\n",
     ")\n",
-    "invariant_massSquared23mc = (\n",
+    "inv_mass_squared_23_mc = (\n",
     "    (mc.E3 + mc.E2) ** 2\n",
     "    - (mc.p3x + mc.p2x) ** 2\n",
     "    - (mc.p3y + mc.p2y) ** 2\n",
@@ -422,20 +435,18 @@
     "fig, ax = plt.subplots(1, 3, tight_layout=True, figsize=(10, 4))\n",
     "\n",
     "# plot the histogram pi+pi-\n",
-    "ax[0].hist(np.sqrt(invariant_massSquared12mc), bins=100, range=(0.2, 1.4))\n",
+    "ax[0].hist(np.sqrt(inv_mass_squared_12_mc), bins=100, range=(0.2, 1.4))\n",
     "ax[0].set_xlabel(\"($\\pi^+\\pi^-$) Invariant mass [GeV]\")\n",
     "ax[0].set_ylabel(\"Entries/(12 MeV)\")\n",
     "ax[0].set_title(\"($\\pi^+\\pi^-$) i.m. \\n\")\n",
     "# plot the histogram pi+p\n",
-    "ax[1].hist(\n",
-    "    np.sqrt(invariant_massSquared13mc), color=\"tomato\", bins=100, range=(1.0, 2.0)\n",
-    ")\n",
+    "ax[1].hist(np.sqrt(inv_mass_squared_13_mc), color=\"tomato\", bins=100, range=(1.0, 2.0))\n",
     "ax[1].set_xlabel(\"($\\pi^+p$) Invariant mass [GeV]\")\n",
     "ax[1].set_ylabel(\"Entries/(10 MeV)\")\n",
     "ax[1].set_title(\"($\\pi^+p$) i.m. \\n\")\n",
     "# plot the histogram pi-pi-\n",
     "ax[2].hist(\n",
-    "    np.sqrt(invariant_massSquared23mc), bins=100, color=\"darkmagenta\", range=(1.0, 2.0)\n",
+    "    np.sqrt(inv_mass_squared_23_mc), bins=100, color=\"darkmagenta\", range=(1.0, 2.0)\n",
     ")\n",
     "ax[2].set_xlabel(\"($\\pi^-p$) Invariant mass [GeV]\")\n",
     "ax[2].set_ylabel(\"Entries/(10 MeV)\")\n",
@@ -465,8 +476,8 @@
    "source": [
     "fig, ax = plt.subplots(1, 2, tight_layout=True, figsize=(7, 4))\n",
     "ax[0].hist2d(\n",
-    "    invariant_massSquared13mc,\n",
-    "    invariant_massSquared12mc,\n",
+    "    inv_mass_squared_13_mc,\n",
+    "    inv_mass_squared_12_mc,\n",
     "    bins=200,\n",
     "    range=[[1.0, 3], [0.0, 0.8]],\n",
     "    cmap=\"jet\",\n",
@@ -474,8 +485,8 @@
     "ax[0].set_xlabel(\"i.m.$^2(\\pi^+p$) [GeV$^2$]\")\n",
     "ax[0].set_ylabel(\"i.m.$^2(\\pi^+\\pi^-$) [GeV$^2$]\")\n",
     "ax[1].hist2d(\n",
-    "    invariant_massSquared13mc,\n",
-    "    invariant_massSquared23mc,\n",
+    "    inv_mass_squared_13_mc,\n",
+    "    inv_mass_squared_23_mc,\n",
     "    bins=200,\n",
     "    range=[[1.0, 3], [1.0, 3.0]],\n",
     "    cmap=\"jet\",\n",
@@ -489,11 +500,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "\n",
-    "---\n",
-    "\n",
-    "\n",
+    "## Missing mass distributions\n",
     "\n",
     "Now, let's take a look to the missing mass distribution (final - initial\n",
     "state). Let's start from the real data using the pylorentz package to build 4-vectors (first, work out *relativisticKinematics.ipynb* notebook)."
@@ -505,47 +512,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import math\n",
-    "\n",
-    "from pylorentz import Momentum4\n",
-    "\n",
     "# final state\n",
-    "p1T = np.sqrt(data.p1x**2 + data.p1y**2)\n",
-    "p1mod = np.sqrt(p1T**2 + data.p1z**2)\n",
-    "eta1 = np.arcsinh(data.p1z / p1T)\n",
-    "phi1 = np.arctan2(data.p1y, data.p1x)\n",
-    "pionPlus = Momentum4.e_eta_phi_p(data.E1, eta1, phi1, p1mod)\n",
-    "\n",
-    "p2T = np.sqrt(data.p2x**2 + data.p2y**2)\n",
-    "p2mod = np.sqrt(p2T**2 + data.p2z**2)\n",
-    "eta2 = np.arcsinh(data.p2z / p2T)\n",
-    "phi2 = np.arctan2(data.p2y, data.p2x)\n",
-    "pionMinus = Momentum4.e_eta_phi_p(data.E2, eta2, phi2, p2mod)\n",
-    "\n",
-    "p3T = np.sqrt(data.p3x**2 + data.p3y**2)\n",
-    "p3mod = np.sqrt(p3T**2 + data.p3z**2)\n",
-    "eta3 = np.arcsinh(data.p3z / p3T)\n",
-    "phi3 = np.arctan2(data.p3y, data.p3x)\n",
-    "proton = Momentum4.e_eta_phi_p(data.E3, eta3, phi3, p3mod)\n",
+    "pip = Momentum4(data.E1, data.p1x, data.p1y, data.p1z)\n",
+    "pim = Momentum4(data.E2, data.p2x, data.p2y, data.p2z)\n",
+    "proton = Momentum4(data.E3, data.p3x, data.p3y, data.p3z)\n",
     "\n",
     "# initial state\n",
-    "# len is the number of events read by the csv file\n",
-    "len = len(data.pgamma)\n",
-    "pgamT = np.zeros(len)\n",
-    "pgammod = data.pgamma\n",
-    "etagam = 1.0e11 * np.ones(len)\n",
-    "phigam = np.zeros(len)\n",
-    "massGamma = 0.0\n",
-    "Egamma = np.sqrt(massGamma**2 + pgammod**2)\n",
-    "photon = Momentum4.e_eta_phi_p(Egamma, etagam, phigam, pgammod)\n",
-    "\n",
-    "# the target (proton) is at rest\n",
-    "massProton = 0.93827\n",
-    "ETgt = massProton * np.ones(len)\n",
-    "etaTgt = np.zeros(len)\n",
-    "phiTgt = np.zeros(len)\n",
-    "pTgt = np.zeros(len)\n",
-    "protonTarget = Momentum4.e_eta_phi_p(ETgt, etaTgt, phiTgt, pTgt)"
+    "m_proton = 0.93827\n",
+    "n_events = len(data)\n",
+    "zeros = np.zeros(n_events)\n",
+    "ones = np.ones(n_events)\n",
+    "gamma = Momentum4(data.pgamma, zeros, zeros, data.pgamma)\n",
+    "target = Momentum4(m_proton * ones, zeros, zeros, zeros)"
    ]
   },
   {
@@ -561,8 +539,8 @@
    },
    "outputs": [],
    "source": [
-    "init = photon + protonTarget\n",
-    "final = pionPlus + pionMinus + proton\n",
+    "init = gamma + target\n",
+    "final = pip + pim + proton\n",
     "missingMomentum = final - init\n",
     "\n",
     "plt.hist(missingMomentum.m2, bins=200, color=\"palegreen\", range=(-0.02, 0.01))\n",
@@ -621,7 +599,7 @@
    },
    "outputs": [],
    "source": [
-    "dipion = pionPlus + pionMinus\n",
+    "dipion = pip + pim\n",
     "missingMomentumDipion = init - dipion\n",
     "\n",
     "plt.hist(missingMomentumDipion.m2, bins=200, color=\"violet\", range=(0.0, 2))\n",
@@ -668,12 +646,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "\n",
     "## Let's do some fits\n",
+    "\n",
     "Which is the maximum of the missing momentum, and where is the peak of the\n",
     "missing mass distribution?\n",
-    "Let's attempt two fits with a single gaussian function.\n"
+    "Let's attempt two fits with a single gaussian function."
    ]
   },
   {
@@ -695,11 +672,11 @@
     "from scipy.optimize import curve_fit\n",
     "\n",
     "# normalize the histogram to 1\n",
-    "lowEdge = 0.015\n",
-    "upEdge = 0.035\n",
-    "hist, bin_edges = np.histogram(missingMomentum.p, 100, range=(lowEdge, upEdge))\n",
-    "integralHist = sum(hist)\n",
-    "hist = hist / integralHist\n",
+    "low_edge = 0.015\n",
+    "up_edge = 0.035\n",
+    "hist, bin_edges = np.histogram(missingMomentum.p, 100, range=(low_edge, up_edge))\n",
+    "integral_hist = sum(hist)\n",
+    "hist = hist / integral_hist\n",
     "\n",
     "n = hist.size\n",
     "x_hist = np.zeros((n), dtype=float)\n",
@@ -779,9 +756,9 @@
     "for ii in range(n):\n",
     "    xf_hist[ii] = (bin_edgesf[ii + 1] + bin_edgesf[ii]) / 2\n",
     "    # find the closest bin to edges\n",
-    "    if bin_edgesf[ii + 1] <= lowEdge:\n",
+    "    if bin_edgesf[ii + 1] <= low_edge:\n",
     "        ilow = ii\n",
-    "    if bin_edgesf[ii + 1] <= upEdge:\n",
+    "    if bin_edgesf[ii + 1] <= up_edge:\n",
     "        iup = ii\n",
     "\n",
     "\n",
@@ -813,11 +790,11 @@
    "outputs": [],
    "source": [
     "# normalize the histogram to 1\n",
-    "lowEdge = -0.001\n",
-    "upEdge = 0.0\n",
-    "hist, bin_edges = np.histogram(missingMomentum.m2, 100, range=(lowEdge, upEdge))\n",
-    "integralHist = sum(hist)\n",
-    "hist = hist / integralHist\n",
+    "low_edge = -0.001\n",
+    "up_edge = 0.0\n",
+    "hist, bin_edges = np.histogram(missingMomentum.m2, 100, range=(low_edge, up_edge))\n",
+    "integral_hist = sum(hist)\n",
+    "hist = hist / integral_hist\n",
     "\n",
     "n = hist.size\n",
     "x_hist = np.zeros((n), dtype=float)\n",
@@ -917,11 +894,11 @@
    "outputs": [],
    "source": [
     "# normalize the histogram to 1\n",
-    "lowEdge = -0.0007\n",
-    "upEdge = 0.0001\n",
-    "hist, bin_edges = np.histogram(missingMomentum.m2, 100, range=(lowEdge, upEdge))\n",
-    "integralHist = sum(hist)\n",
-    "hist = hist / integralHist\n",
+    "low_edge = -0.0007\n",
+    "up_edge = 0.0001\n",
+    "hist, bin_edges = np.histogram(missingMomentum.m2, 100, range=(low_edge, up_edge))\n",
+    "integral_hist = sum(hist)\n",
+    "hist = hist / integral_hist\n",
     "\n",
     "n = hist.size\n",
     "x_hist = np.zeros((n), dtype=float)\n",
@@ -1046,11 +1023,11 @@
    "outputs": [],
    "source": [
     "# normalize the histogram to 1\n",
-    "lowEdge = 0.8\n",
-    "upEdge = 1.0\n",
-    "hist, bin_edges = np.histogram(missingMomentumDipion.m2, 100, range=(lowEdge, upEdge))\n",
-    "integralHist = sum(hist)\n",
-    "hist = hist / integralHist\n",
+    "low_edge = 0.8\n",
+    "up_edge = 1.0\n",
+    "hist, bin_edges = np.histogram(missingMomentumDipion.m2, 100, range=(low_edge, up_edge))\n",
+    "integral_hist = np.sum(hist)\n",
+    "hist = hist / integral_hist\n",
     "\n",
     "n = hist.size\n",
     "x_hist = np.zeros((n), dtype=float)\n",

--- a/lecture12b-kinematics.ipynb
+++ b/lecture12b-kinematics.ipynb
@@ -32,48 +32,52 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "mystnb": {
+     "code_prompt_show": "Import Python libraries"
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
    "outputs": [],
    "source": [
+    "import gdown\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import pandas as pd"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Import the data file (csv format) into your Google Colab. Instead of mounting the \"*/content/drive/MyDrive*\" folder, there is an alternative way to download the data file to your Colab folder and access it directly. To do this,  install the **gdown** module of python, in the following way:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then you import the full gdown package and you pick the file you need. The most difficult thing is to file the url address of the file, which can be done inquiring the properties of the file through the web gdrive interface."
+    "import pandas as pd\n",
+    "from pylorentz import Momentum4"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
-    "import gdown\n",
-    "\n",
-    "# now you use the url pointing to the data file\n",
-    "# the url is obtained from inquiring the file address in google drive\n",
-    "\n",
-    "# real experimental data\n",
-    "# exp_nbarp-2pip1pim_93.csv\n",
     "output_path = gdown.cached_download(\n",
     "    url=\"https://drive.google.com/uc?id=17J4rrO-NHL8whkd7hjELhJbCoanoaqam\",\n",
     "    path=\"data/antineutron_3pi.dat\",\n",
     "    md5=\"5ff45076c9d921aa0c9c803b8d2d8958\",\n",
     "    quiet=True,\n",
     ")\n",
-    "data = pd.read_csv(output_path)"
+    "data = pd.read_csv(output_path)\n",
+    "data.columns = data.columns.str.strip()\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> The columns headers present some trailing blanks, that must be dropped to be able to use correctly the DataFormat structure (if not, they deliver an error message). To do so, the `str.strip()` method must be used beforehand to reformat the column shape."
    ]
   },
   {
@@ -87,134 +91,54 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The columns headers present some trailing blanks, that must be dropped to be able to use correctly the DataFormat structure (if not, they deliver an error message). To do so, the *str.strip()* function must be used beforehand to reformat the column shape.\n",
-    "In the following commands in the cell, columns are shown, overall with the data.columns command, and per single variable (like *data.p2x*). If the format is correct, no error should appear."
+    "Load the [`pylorentz`](https://github.com/PyLorentz/PyLorentz) package (if not available, install it with `pip install pylorentz`). Let's import the arrays from the csv table into Momentum4 objects and repeat the calculation of invariant masses and other observables. We are working with *numpy arrays* whose length is equale to the number of entries of the table read from the csv file."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data.columns = data.columns.str.strip()\n",
-    "data.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Load the **pylorentz package** (if not available, install it with `pip install pylorentz`).\n",
-    "\n",
-    "The pylorentz package defines particle 4-momenta through the quantities\n",
-    "\n",
-    "*   $E,\\; \\eta,\\; \\phi,\\; p\\;$ or\n",
-    "*   $E,\\; \\eta,\\; \\phi,\\; p_T\\;$\n",
-    "*   $E,\\; m,\\; \\eta,\\; \\phi\\;$\n",
-    "*   $m,\\; \\eta,\\; \\phi,\\; p_T\\;$\n",
-    "*   $m,\\; \\eta,\\; \\phi,\\; p\\;$\n",
-    "\n",
-    "They are related to the cartesian coordinates of the particle 3-momentum through the following relationships:\n",
-    "\n",
-    "> $p = \\sqrt{p_x^2 + p_y^2 + p_z^2}$\n",
-    "\n",
-    "> $p_T = \\sqrt{p_x^2 + p_y^2}$\n",
-    "\n",
-    "> $p_x = p_T\\cos\\phi = p\\cos\\phi\\sin\\theta$\n",
-    "\n",
-    "> $p_y = p_T\\sin\\phi = p\\sin\\phi\\sin\\theta$\n",
-    "\n",
-    "> $p_z = p_T\\sinh\\eta = p\\cos\\theta $\n",
-    "\n",
-    "from which one can derive\n",
-    "\n",
-    "> $\\phi = \\tan^{-1}(p_y/p_x)$\n",
-    "\n",
-    "> $\\theta = \\cos^{-1}(p_z/p)$\n",
-    "\n",
-    "> $\\eta = -\\ln(\\tan(\\theta/2)$\n",
-    "\n",
-    "The pylorentz package provides functions for the evaluation of the magnitude of the 4-momentum vector, of the kinematic angles and their sum (which is convenient for particles systems).\n",
-    "\n",
-    "\n",
-    "  \n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import math\n",
-    "\n",
-    "from pylorentz import Momentum4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's import the arrays from the csv table into Momentum4 objects and repeat the calculation of invariant masses and other observables. We are working with *numpy arrays* whose length is equale to the number of entries of the table read from the csv file."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# final state\n",
-    "p1T = np.sqrt(data.p1x**2 + data.p1y**2)\n",
-    "p1mod = np.sqrt(p1T**2 + data.p1z**2)\n",
-    "eta1 = np.arcsinh(data.p1z / p1T)\n",
-    "phi1 = np.arctan2(data.p1y, data.p1x)\n",
-    "pion1 = Momentum4.e_eta_phi_p(data.E1, eta1, phi1, p1mod)\n",
-    "\n",
-    "p2T = np.sqrt(data.p2x**2 + data.p2y**2)\n",
-    "p2mod = np.sqrt(p2T**2 + data.p2z**2)\n",
-    "eta2 = np.arcsinh(data.p2z / p2T)\n",
-    "phi2 = np.arctan2(data.p2y, data.p2x)\n",
-    "pion2 = Momentum4.e_eta_phi_p(data.E2, eta2, phi2, p2mod)\n",
-    "\n",
-    "p3T = np.sqrt(data.p3x**2 + data.p3y**2)\n",
-    "p3mod = np.sqrt(p3T**2 + data.p3z**2)\n",
-    "eta3 = np.arcsinh(data.p3z / p3T)\n",
-    "phi3 = np.arctan2(data.p3y, data.p3x)\n",
-    "pion3 = Momentum4.e_eta_phi_p(data.E3, eta3, phi3, p3mod)\n",
+    "pi1 = Momentum4(data.E1, data.p1x, data.p1y, data.p1z)\n",
+    "pi2 = Momentum4(data.E2, data.p2x, data.p2y, data.p2z)\n",
+    "pi3 = Momentum4(data.E3, data.p3x, data.p3y, data.p3z)\n",
     "\n",
     "# initial state\n",
-    "# len is the number of events read by the csv file\n",
-    "len = data.pnbar.size\n",
-    "pnbT = np.zeros(len)\n",
-    "pnbmod = data.pnbar\n",
-    "etanb = 1.0e11 * np.ones(len)\n",
-    "phinb = np.zeros(len)\n",
-    "massNeutron = 0.93956\n",
-    "Enb = np.sqrt(massNeutron**2 + pnbmod**2)\n",
-    "antineutron = Momentum4.e_eta_phi_p(Enb, etanb, phinb, pnbmod)\n",
-    "\n",
-    "# the target (proton) is at rest\n",
-    "massProton = 0.93827\n",
-    "ETgt = massProton * np.ones(len)\n",
-    "etaTgt = np.zeros(len)\n",
-    "phiTgt = np.zeros(len)\n",
-    "pTgt = np.zeros(len)\n",
-    "protonTarget = Momentum4.e_eta_phi_p(ETgt, etaTgt, phiTgt, pTgt)"
+    "m_neutron = 0.93956\n",
+    "m_proton = 0.93827\n",
+    "n_events = len(data)\n",
+    "zeros = np.zeros(n_events)\n",
+    "ones = np.ones(n_events)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "system12 = pion1 + pion2\n",
-    "system23 = pion2 + pion3\n",
-    "system13 = pion1 + pion3\n",
+    "E_nbar = np.sqrt(m_neutron**2 + data.pnbar**2)\n",
+    "nbar = Momentum4(E_nbar, zeros, zeros, data.pnbar)\n",
+    "target = Momentum4(m_proton * ones, zeros, zeros, zeros)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "system12 = pi1 + pi2\n",
+    "system23 = pi2 + pi3\n",
+    "system13 = pi1 + pi3\n",
     "\n",
     "invariantMassSquared12 = system12.m2\n",
     "invariantMassSquared13 = system13.m2\n",
@@ -231,13 +155,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "plt.hist(antineutron.p, bins=100, color=\"aquamarine\", alpha=0.7)\n",
+    "plt.hist(nbar.p, bins=100, color=\"aquamarine\", alpha=0.7)\n",
     "plt.xlabel(\"Antineutron momentum [GeV/c]\")\n",
     "plt.ylabel(\"Entries/(4 MeV/c)\")\n",
-    "plt.title(\"The histogram of the momentum of the incoming antineutron \\n\")"
+    "plt.title(\"The histogram of the momentum of the incoming antineutron \\n\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -250,7 +180,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input",
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 2, tight_layout=True, figsize=(9, 4))\n",
@@ -263,7 +201,8 @@
     "h1 = ax[1].hist2d(invariantMassSquared23, invariantMassSquared13, bins=100, cmap=\"jet\")\n",
     "fig.colorbar(h1[3], ax=ax[1])\n",
     "ax[1].set_xlabel(\"i.m.$^2(\\pi^+_1\\pi^-$) [GeV$^2$]\")\n",
-    "ax[1].set_ylabel(\"i.m.$^2(\\pi^+_2\\pi^-$) [GeV$^2$]\")"
+    "ax[1].set_ylabel(\"i.m.$^2(\\pi^+_2\\pi^-$) [GeV$^2$]\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -279,30 +218,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "centerOfMass = antineutron + protonTarget\n",
-    "\n",
-    "# to boost particles in the center of mass reference system, use the - sign\n",
-    "pion1CM = pion1.boost_particle(-centerOfMass)\n",
-    "pion2CM = pion2.boost_particle(-centerOfMass)\n",
-    "pion3CM = pion3.boost_particle(-centerOfMass)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "antineutronCM = antineutron.boost_particle(-centerOfMass)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "protonTargetCM = protonTarget.boost_particle(-centerOfMass)"
+    "cm = nbar + target\n",
+    "pi1_cm = pi1.boost_particle(-cm)\n",
+    "pi2_cm = pi2.boost_particle(-cm)\n",
+    "pi3_cm = pi3.boost_particle(-cm)\n",
+    "nbar_cm = nbar.boost_particle(-cm)\n",
+    "target_cm = target.boost_particle(-cm)"
    ]
   },
   {
@@ -320,10 +241,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "s_lab = centerOfMass.m2\n",
+    "s_lab = cm.m2\n",
     "print(s_lab)"
    ]
   },
@@ -333,7 +256,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "initCM = antineutronCM + protonTargetCM\n",
+    "initCM = nbar_cm + target_cm\n",
     "s_cm = initCM.m2\n",
     "print(s_cm)\n",
     "\n",
@@ -343,13 +266,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "plt.hist(s_lab, bins=100, color=\"MediumPurple\")\n",
     "plt.xlabel(\"s [(GeV/$c^2)^2$]\")\n",
     "plt.ylabel(\"Entries/(1.6 (MeV/$c^2)^2$)\")\n",
-    "plt.title(\"Available energy for the reaction \\n\")"
+    "plt.title(\"Available energy for the reaction \\n\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -372,17 +303,25 @@
    "outputs": [],
    "source": [
     "dipion = system13\n",
-    "t_lab_1 = (antineutron - dipion).m2\n",
-    "t_lab_2 = (protonTarget - pion2).m2\n",
-    "dipionCM = system13.boost_particle(-centerOfMass)\n",
-    "t_cm_1 = (antineutronCM - dipionCM).m2\n",
-    "t_cm_2 = (protonTargetCM - pion2CM).m2"
+    "t_lab_1 = (nbar - dipion).m2\n",
+    "t_lab_2 = (target - pi2).m2\n",
+    "dipion_cm = system13.boost_particle(-cm)\n",
+    "t_cm_1 = (nbar_cm - dipion_cm).m2\n",
+    "t_cm_2 = (target_cm - pi2_cm).m2"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "full-width",
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(2, 2, tight_layout=True, figsize=(9, 4))\n",
@@ -393,7 +332,8 @@
     "ax[1, 0].hist(t_cm_1, bins=100, color=\"GreenYellow\")\n",
     "ax[1, 0].set_xlabel(\"t = $(p_{nbar} - p_D)^2$ CM RF [$(\\mathrm{GeV}/c^2)^2$]\")\n",
     "ax[1, 1].hist(t_cm_2, bins=100, color=\"LawnGreen\")\n",
-    "ax[1, 1].set_xlabel(\"t = $(p_p - p_{\\pi^+_2})^2$ CM RF [$(\\mathrm{GeV}/c^2)^2$]\")"
+    "ax[1, 1].set_xlabel(\"t = $(p_p - p_{\\pi^+_2})^2$ CM RF [$(\\mathrm{GeV}/c^2)^2$]\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -409,16 +349,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "u_lab_1 = (antineutron - pion2).m2\n",
-    "u_lab_2 = (protonTarget - dipion).m2\n",
-    "u_cm_1 = (antineutronCM - pion2CM).m2\n",
-    "u_cm_2 = (protonTargetCM - dipionCM).m2"
+    "u_lab_1 = (nbar - pi2).m2\n",
+    "u_lab_2 = (target - dipion).m2\n",
+    "u_cm_1 = (nbar_cm - pi2_cm).m2\n",
+    "u_cm_2 = (target_cm - dipion_cm).m2"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input",
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(2, 2, tight_layout=True, figsize=(9, 4))\n",
@@ -429,14 +377,15 @@
     "ax[1, 0].hist(u_cm_1, bins=100, color=\"Fuchsia\")\n",
     "ax[1, 0].set_xlabel(\"u = $(p_{nbar} - p_{\\pi^+_2})^2$ CM RF [$(\\mathrm{GeV}/c^2)^2$]\")\n",
     "ax[1, 1].hist(u_cm_2, bins=100, color=\"DarkMagenta\")\n",
-    "ax[1, 1].set_xlabel(\"u = $(p_p - p_D)^2$ CM RF [$(\\mathrm{GeV}/c^2)^2$]\")"
+    "ax[1, 1].set_xlabel(\"u = $(p_p - p_D)^2$ CM RF [$(\\mathrm{GeV}/c^2)^2$]\")\n",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Test: $\\; s + t + u = m_1^2 + m_2^2 + m_3^2 + m_4^2$"
+    "Test if $\\; s + t + u = m_1^2 + m_2^2 + m_3^2 + m_4^2$"
    ]
   },
   {
@@ -445,27 +394,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sum = s_lab + t_lab_1 + u_lab_1"
+    "mandelstam_sum = s_lab + t_lab_1 + u_lab_1\n",
+    "m2_sum = m_neutron**2 + m_proton**2 + dipion_cm.m2 + pi2_cm.m2"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
-    "sumOfMasses = (massNeutron**2 + massProton**2 + dipionCM.m2 + pion2CM.m2) * np.ones(\n",
-    "    len\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.hist(sum - sumOfMasses, bins=100, color=\"CornFlowerBlue\")"
+    "plt.hist(mandelstam_sum - m2_sum, bins=100, color=\"CornFlowerBlue\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -482,14 +429,14 @@
    "outputs": [],
    "source": [
     "# missing mass between initial and final state\n",
-    "initialState4Mom = centerOfMass\n",
-    "finalState4Mom = pion1 + pion2 + pion3\n",
-    "missing4Momentum = initialState4Mom - finalState4Mom\n",
+    "p4_initial_state = cm\n",
+    "p4_final_state = pi1 + pi2 + pi3\n",
+    "p4_missing = p4_initial_state - p4_final_state\n",
     "# missing mass recoiling against the neutral dipion systems (there are two)\n",
-    "dipion1 = pion1 + pion3\n",
-    "dipion2 = pion2 + pion3\n",
-    "recoilingMissingMass1 = finalState4Mom - dipion1\n",
-    "recoilingMissingMass2 = finalState4Mom - dipion2"
+    "dipion1 = pi1 + pi3\n",
+    "dipion2 = pi2 + pi3\n",
+    "recoiling_missing_mass1 = p4_final_state - dipion1\n",
+    "recoiling_missing_mass2 = p4_final_state - dipion2"
    ]
   },
   {
@@ -502,23 +449,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "full-width",
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 3, tight_layout=True, figsize=(11, 3.5))\n",
-    "ax[0].hist(missing4Momentum.m2, bins=100, color=\"crimson\")\n",
+    "ax[0].hist(p4_missing.m2, bins=100, color=\"crimson\")\n",
     "ax[0].set_xlabel(\"m.m. [$(\\mathrm{GeV}/c^2)^2$]\")\n",
     "# ptot vs Etot plot\n",
-    "h1 = ax[1].hist2d(finalState4Mom.e, finalState4Mom.p, bins=100, cmap=\"rainbow\")\n",
+    "h1 = ax[1].hist2d(p4_final_state.e, p4_final_state.p, bins=100, cmap=\"rainbow\")\n",
     "fig.colorbar(h1[3], ax=ax[1])\n",
     "ax[1].set_xlabel(\"$\\mathrm{E}_{tot}(2\\pi^+\\pi^-)$ [GeV]\")\n",
     "ax[1].set_ylabel(\"$\\mathrm{p}_{tot}(2\\pi^+\\pi^-)$ [GeV/c]\")\n",
     "# missing mass recoiling against the neutral dipion (2 entries/event)\n",
-    "allMissingDipion = np.concatenate([recoilingMissingMass1.m2, recoilingMissingMass2.m2])\n",
-    "missingHisto = ax[2].hist(allMissingDipion, bins=100, color=\"darkorange\")\n",
+    "all_missing_dipion = np.concatenate(\n",
+    "    [recoiling_missing_mass1.m2, recoiling_missing_mass2.m2]\n",
+    ")\n",
+    "missingHisto = ax[2].hist(all_missing_dipion, bins=100, color=\"darkorange\")\n",
     "ax[2].set_xlabel(\"m.m. recoiling against $(\\pi^+\\pi^-)$ [$(\\mathrm{GeV}/c^2)^2$]\")\n",
     "ax[2].xaxis.get_label().set_fontsize(8)\n",
-    "ax[2].tick_params(axis=\"both\", which=\"major\", labelsize=8)"
+    "ax[2].tick_params(axis=\"both\", which=\"major\", labelsize=8)\n",
+    "plt.show()"
    ]
   },
   {
@@ -531,18 +489,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import matplotlib.mlab as mlab\n",
     "from scipy.stats import norm\n",
     "\n",
     "# best fit of data\n",
-    "(mu, sigma) = norm.fit(allMissingDipion)\n",
+    "mu, sigma = norm.fit(all_missing_dipion)\n",
     "\n",
     "# the histogram of the data\n",
     "n, bins, patches = plt.hist(\n",
-    "    allMissingDipion,\n",
+    "    all_missing_dipion,\n",
     "    range=(0.01947835, 0.01947985),\n",
     "    density=True,\n",
     "    facecolor=\"darkorange\",\n",
@@ -552,23 +515,31 @@
     "# add a 'best fit' line\n",
     "y = norm.pdf(bins, mu, sigma)\n",
     "l = plt.plot(bins, y, \"r--\", linewidth=2)\n",
-    "\n",
-    "# plot\n",
-    "plt.xlabel(\"missing mass recoiling against the neutral dipion\")\n",
-    "plt.ylabel(\"counts\")\n",
-    "plt.title(r\"$\\mu=%.3f,\\ \\sigma=%.3f$\" % (mu, sigma))\n",
-    "plt.grid(True)\n",
-    "plt.hist(allMissingDipion, 100, density=True, facecolor=\"orange\", histtype=\"barstacked\")\n",
-    "\n",
     "print(\"The missing mass in GeV/c^2 is: \", np.sqrt(mu))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "plt.xlabel(\"missing mass recoiling against the neutral dipion\")\n",
+    "plt.ylabel(\"counts\")\n",
+    "plt.title(r\"$\\mu=%.3f,\\ \\sigma=%.3f$\" % (mu, sigma))\n",
+    "plt.grid(True)\n",
+    "plt.hist(\n",
+    "    all_missing_dipion, 100, density=True, facecolor=\"orange\", histtype=\"barstacked\"\n",
+    ")\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {

--- a/lecture12c-angles.ipynb
+++ b/lecture12c-angles.ipynb
@@ -10,14 +10,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Prepare the notebook with the preambles for the inclusion of pandas, numpy and matplotlib.pyplot.\n",
-    "Import the data file (csv format) into Google Colab through the drive.mount command, import the pylorentz package."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -33,57 +25,52 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "mystnb": {
+     "code_prompt_show": "Import Python libraries"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
+    "import math\n",
+    "\n",
+    "import gdown\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from pylorentz import Momentum4"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again we copy locally the data file using the gdown python package (alternative to mounting the data folder)"
+    "Again we download the data file using the [`gdown`](https://github.com/wkentaro/gdown) package:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
-    "import gdown\n",
-    "\n",
     "output_path = gdown.cached_download(\n",
     "    url=\"https://drive.google.com/uc?id=1qiYjPbR5nx3_Sw7MXuUKhNAUpkXPoxYh\",\n",
     "    path=\"data/gammapi_2pions_inclusive.dat\",\n",
     "    md5=\"38cf5bf915318df756a21a82ad9e4afa\",\n",
     "    quiet=True,\n",
     ")\n",
-    "data = pd.read_csv(output_path)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data.head()\n",
-    "# data.columns = data.columns.str.strip()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import math\n",
-    "\n",
-    "from pylorentz import Momentum4"
+    "data = pd.read_csv(output_path)\n",
+    "data.columns = data.columns.str.strip()\n",
+    "data"
    ]
   },
   {
@@ -96,74 +83,43 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data.columns = data.columns.str.strip()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# final state\n",
-    "p1T = np.sqrt(data.p1x**2 + data.p1y**2)\n",
-    "p1mod = np.sqrt(p1T**2 + data.p1z**2)\n",
-    "eta1 = np.arcsinh(data.p1z / p1T)\n",
-    "phi1 = np.arctan2(data.p1y, data.p1x)\n",
-    "pionPlus = Momentum4.e_eta_phi_p(data.E1, eta1, phi1, p1mod)\n",
-    "\n",
-    "p2T = np.sqrt(data.p2x**2 + data.p2y**2)\n",
-    "p2mod = np.sqrt(p2T**2 + data.p2z**2)\n",
-    "eta2 = np.arcsinh(data.p2z / p2T)\n",
-    "phi2 = np.arctan2(data.p2y, data.p2x)\n",
-    "pionMinus = Momentum4.e_eta_phi_p(data.E2, eta2, phi2, p2mod)\n",
-    "\n",
-    "p3T = np.sqrt(data.p3x**2 + data.p3y**2)\n",
-    "p3mod = np.sqrt(p3T**2 + data.p3z**2)\n",
-    "eta3 = np.arcsinh(data.p3z / p3T)\n",
-    "phi3 = np.arctan2(data.p3y, data.p3x)\n",
-    "proton = Momentum4.e_eta_phi_p(data.E3, eta3, phi3, p3mod)\n",
+    "pip = Momentum4(data.E1, data.p1x, data.p1y, data.p1z)\n",
+    "pim = Momentum4(data.E2, data.p2x, data.p2y, data.p2z)\n",
+    "proton = Momentum4(data.E3, data.p3x, data.p3y, data.p3z)\n",
     "\n",
     "# initial state\n",
-    "# alen is the number of events read by the csv file\n",
-    "len = len(data.pgamma)\n",
-    "pgammaT = np.zeros(len)\n",
-    "pgammamod = data.pgamma\n",
-    "etagamma = 1.0e11 * np.ones(len)\n",
-    "phigamma = np.zeros(len)\n",
-    "massGamma = 0.0\n",
-    "Egamma = np.sqrt(massGamma**2 + pgammamod**2)\n",
-    "gamma = Momentum4.e_eta_phi_p(Egamma, etagamma, phigamma, pgammamod)\n",
-    "\n",
-    "# the target (proton) is at rest\n",
-    "massProton = 0.93827\n",
-    "ETgt = massProton * np.ones(len)\n",
-    "etaTgt = np.zeros(len)\n",
-    "phiTgt = np.zeros(len)\n",
-    "pTgt = np.zeros(len)\n",
-    "protonTarget = Momentum4.e_eta_phi_p(ETgt, etaTgt, phiTgt, pTgt)"
+    "n_events = len(data)\n",
+    "zeros = np.zeros(n_events)\n",
+    "ones = np.ones(n_events)\n",
+    "m_proton = 0.93827\n",
+    "gamma = Momentum4(data.pgamma, zeros, zeros, data.pgamma)\n",
+    "target = Momentum4(m_proton * ones, zeros, zeros, zeros)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# 4-momenta in the scenter of mass system\n",
-    "centerOfMass = gamma + protonTarget\n",
+    "cm = gamma + target\n",
+    "pip_cm = pip.boost_particle(-cm)\n",
+    "pim_cm = pim.boost_particle(-cm)\n",
+    "proton_cm = proton.boost_particle(-cm)\n",
     "\n",
-    "pionPlusCM = pionPlus.boost_particle(-centerOfMass)\n",
-    "pionMinusCM = pionMinus.boost_particle(-centerOfMass)\n",
-    "protonCM = proton.boost_particle(-centerOfMass)\n",
-    "\n",
-    "k = gamma.boost_particle(-centerOfMass)\n",
-    "protonTargetCM = protonTarget.boost_particle(-centerOfMass)\n",
-    "q = pionPlusCM + pionMinusCM\n",
-    "kcmDipion = gamma.boost_particle(-q)"
+    "k = gamma.boost_particle(-cm)\n",
+    "target_cm = target.boost_particle(-cm)\n",
+    "q = pip_cm + pim_cm\n",
+    "k_cm_di_pion = gamma.boost_particle(-q)"
    ]
   },
   {
@@ -184,8 +140,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Angular distributions in helicity frame\n",
-    "\n",
+    "## Angular distributions in helicity frame"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Angles and particle directions can be visualised in different reference frames in which resonance properties can emerge more easily.\n",
     "The decay distribution of the dipion may be discussed in the\n",
     " **helicity reference system**, defined as follows:\n",
@@ -203,16 +164,7 @@
     "\n",
     "*   $\\cos\\theta = \\mathbf{n\\cdot z}$\n",
     "*   $\\cos\\phi = \\frac{\\mathbf{y\\cdot(z\\times n)}}{|\\mathbf{z\\times n}|}$\n",
-    "*   $\\sin\\phi = -\\frac{\\mathbf{x\\cdot(z\\times n)}} {|\\mathbf{z\\times n}|}$\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n"
+    "*   $\\sin\\phi = -\\frac{\\mathbf{x\\cdot(z\\times n)}} {|\\mathbf{z\\times n}|}$"
    ]
   },
   {
@@ -228,35 +180,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n = []\n",
-    "z = []\n",
-    "y = []\n",
-    "x = []\n",
-    "zcrossn = []\n",
-    "cosTheta = []\n",
-    "cosPhi = []\n",
-    "sinPhi = []\n",
-    "phiHel = []\n",
-    "# len = len(data.p1x)\n",
-    "# for 5000 events: 50 s\n",
-    "len = 10000\n",
-    "for i in range(len):\n",
-    "    n = np.array([pionPlusCM.p_x[i], pionPlusCM.p_y[i], pionPlusCM.p_z[i]])\n",
-    "    n /= pionPlusCM.p[i]\n",
-    "    z = np.array([q.p_x[i], q.p_y[i], q.p_z[i]])\n",
-    "    z /= q.p[i]\n",
-    "    k3 = np.array([k.p_x[i], k.p_y[i], k.p_z[i]])\n",
-    "    q3 = np.array([q.p_x[i], q.p_y[i], q.p_z[i]])\n",
-    "    y = np.cross(k3, q3)\n",
-    "    y /= np.linalg.norm(y)\n",
-    "    x = np.cross(y, z)\n",
-    "    cosTheta.append(np.dot(n, z))\n",
-    "    zcrossn = np.cross(z, n)\n",
-    "    cosPhi.append(np.dot(y, zcrossn) / np.linalg.norm(zcrossn))\n",
-    "    sinPhi.append(-np.dot(x, zcrossn) / np.linalg.norm(zcrossn))\n",
-    "    # extraction of the phi angle\n",
-    "    # the angle spans the (-pi, +pi) range and its sign is taken correctly into account by the arctan2 function\n",
-    "    phiHel.append(np.arctan2(sinPhi[i], cosPhi[i]))"
+    "n = pip_cm[1:] / pip_cm.p\n",
+    "z = q[1:] / q.p\n",
+    "y = np.cross(k[1:], q[1:], axis=0)\n",
+    "y /= np.linalg.norm(y, axis=0)\n",
+    "x = np.cross(y, z, axis=0)\n",
+    "cos_theta = np.sum(n * z, axis=0)\n",
+    "z_cross_n = np.cross(z, n, axis=0)\n",
+    "cos_phi = np.sum(y * z_cross_n, axis=0) / np.linalg.norm(z_cross_n, axis=0)\n",
+    "sin_phi = -np.sum(x * z_cross_n, axis=0) / np.linalg.norm(z_cross_n, axis=0)\n",
+    "phi_helicity = np.arctan2(sin_phi, cos_phi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note on the extraction of the $\\phi$&nbsp;angle: the angle spans the $(-\\pi, +\\pi)$ range and its sign is taken correctly into account by the `arctan2` function."
    ]
   },
   {
@@ -269,31 +209,43 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 4, tight_layout=True, figsize=(13, 4))\n",
-    "\n",
-    "ax[0].hist(cosTheta, bins=50, color=\"aqua\")\n",
+    "ax[0].hist(cos_theta, bins=50, color=\"aqua\")\n",
     "ax[0].set_xlabel(\"cos(theta)\")\n",
     "ax[0].set_ylabel(\"Entries/0.01\")\n",
-    "ax[1].hist(cosPhi, color=\"lightskyblue\", bins=50)\n",
+    "ax[1].hist(cos_phi, color=\"lightskyblue\", bins=50)\n",
     "ax[1].set_xlabel(\"$\\cos\\phi$\")\n",
     "ax[1].set_ylabel(\"Entries/0.01\")\n",
-    "ax[2].hist(sinPhi, bins=50, color=\"slateblue\")\n",
+    "ax[2].hist(sin_phi, bins=50, color=\"slateblue\")\n",
     "ax[2].set_xlabel(\"$\\sin\\phi$\")\n",
     "ax[2].set_ylabel(\"Entries/0.01\")\n",
-    "ax[3].hist(phiHel, bins=50, color=\"darkorchid\")\n",
+    "ax[3].hist(phi_helicity, bins=50, color=\"darkorchid\")\n",
     "ax[3].set_xlabel(\"$\\phi_{hel}$ [rad]\")\n",
-    "ax[3].set_ylabel(\"Entries/(0.13 rad)\")"
+    "ax[3].set_ylabel(\"Entries/(0.13 rad)\")\n",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Angular distributions in the Gottfried-Jackson frame\n",
-    "\n",
+    "## Angular distributions in the Gottfried-Jackson frame"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Differently from the helicity system, in the **Gottfried-Jackson** system the $z$ axis is equal to the direction of flight of the incoming photon in the D rest frame. Having replaced the $z$ axis, all other vectors definitions follow accordingly."
    ]
   },
@@ -303,56 +255,58 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phiGJ = []\n",
-    "cosPhi = []\n",
-    "sinPhi = []\n",
-    "cosTheta = []\n",
-    "\n",
-    "for i in range(len):\n",
-    "    n = np.array([pionPlusCM.p_x[i], pionPlusCM.p_y[i], pionPlusCM.p_z[i]])\n",
-    "    n /= pionPlusCM.p[i]\n",
-    "    z = np.array([kcmDipion.p_x[i], kcmDipion.p_y[i], kcmDipion.p_z[i]])\n",
-    "    z /= kcmDipion.p[i]\n",
-    "    k3 = np.array([k.p_x[i], k.p_y[i], k.p_z[i]])\n",
-    "    q3 = np.array([q.p_x[i], q.p_y[i], q.p_z[i]])\n",
-    "    y = np.cross(k3, q3)\n",
-    "    y /= np.linalg.norm(y)\n",
-    "    x = np.cross(y, z)\n",
-    "    cosTheta.append(np.dot(n, z))\n",
-    "    zcrossn = np.cross(z, n)\n",
-    "    cosPhi.append(np.dot(y, zcrossn) / np.linalg.norm(zcrossn))\n",
-    "    sinPhi.append(-np.dot(x, zcrossn) / np.linalg.norm(zcrossn))\n",
-    "    phiGJ.append(np.arctan2(sinPhi[i], cosPhi[i]))"
+    "n = pip_cm[1:] / pip_cm.p\n",
+    "z = k_cm_di_pion[1:] / k_cm_di_pion.p\n",
+    "y = np.cross(k[1:], q[1:], axis=0)\n",
+    "y /= np.linalg.norm(y)\n",
+    "x = np.cross(y, z, axis=0)\n",
+    "cos_theta = np.sum(n * z, axis=0)\n",
+    "z_cross_n = np.cross(z, n, axis=0)\n",
+    "cos_phi = np.sum(y * z_cross_n, axis=0) / np.linalg.norm(z_cross_n)\n",
+    "sin_phi = -np.sum(x * z_cross_n, axis=0) / np.linalg.norm(z_cross_n)\n",
+    "phi_GJ = np.arctan2(sin_phi, cos_phi)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 4, tight_layout=True, figsize=(13, 4))\n",
-    "\n",
-    "ax[0].hist(cosTheta, bins=50, color=\"aqua\", alpha=0.66)\n",
+    "ax[0].hist(cos_theta, bins=50, color=\"aqua\", alpha=0.66)\n",
     "ax[0].set_xlabel(\"cos(theta)\")\n",
     "ax[0].set_ylabel(\"Entries/0.01\")\n",
-    "ax[1].hist(cosPhi, color=\"lightskyblue\", bins=50, alpha=0.66)\n",
+    "ax[1].hist(cos_phi, color=\"lightskyblue\", bins=50, alpha=0.66)\n",
     "ax[1].set_xlabel(\"$\\cos\\phi$\")\n",
     "ax[1].set_ylabel(\"Entries/0.01\")\n",
-    "ax[2].hist(sinPhi, bins=50, color=\"slateblue\", alpha=0.66)\n",
+    "ax[2].hist(sin_phi, bins=50, color=\"slateblue\", alpha=0.66)\n",
     "ax[2].set_xlabel(\"$\\sin\\phi$\")\n",
     "ax[2].set_ylabel(\"Entries/0.01\")\n",
-    "ax[3].hist(phiGJ, bins=50, color=\"darkorchid\", alpha=0.66)\n",
+    "ax[3].hist(phi_GJ, bins=50, color=\"darkorchid\", alpha=0.66)\n",
     "ax[3].set_xlabel(\"$\\phi_{GJ}$ [rad]\")\n",
-    "ax[3].set_ylabel(\"Entries/(0.13 rad)\")"
+    "ax[3].set_ylabel(\"Entries/(0.13 rad)\")\n",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Angular distributions in the Adair frame\n",
-    "\n",
+    "## Angular distributions in the Adair frame"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "On the other hand, in the **Adair** system the $z$ is equal to the direction of flight of the incoming photon in the c.m. system of the reaction. All other definition follow, as above."
    ]
   },
@@ -362,48 +316,45 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phiAdair = []\n",
-    "cosPhi = []\n",
-    "sinPhi = []\n",
-    "cosTheta = []\n",
-    "\n",
-    "for i in range(len):\n",
-    "    n = np.array([pionPlusCM.p_x[i], pionPlusCM.p_y[i], pionPlusCM.p_z[i]])\n",
-    "    n /= pionPlusCM.p[i]\n",
-    "    z = np.array([k.p_x[i], k.p_y[i], k.p_z[i]])\n",
-    "    z /= k.p[i]\n",
-    "    k3 = np.array([k.p_x[i], k.p_y[i], k.p_z[i]])\n",
-    "    q3 = np.array([q.p_x[i], q.p_y[i], q.p_z[i]])\n",
-    "    y = np.cross(k3, q3)\n",
-    "    y /= np.linalg.norm(y)\n",
-    "    x = np.cross(y, z)\n",
-    "    cosTheta.append(np.dot(n, z))\n",
-    "    zcrossn = np.cross(z, n)\n",
-    "    cosPhi.append(np.dot(y, zcrossn) / np.linalg.norm(zcrossn))\n",
-    "    sinPhi.append(-np.dot(x, zcrossn) / np.linalg.norm(zcrossn))\n",
-    "    phiAdair.append(np.arctan2(sinPhi[i], cosPhi[i]))"
+    "n = pip_cm[1:] / pip_cm.p\n",
+    "z = k[1:] / k.p\n",
+    "y = np.cross(k[1:], q[1:], axis=0)\n",
+    "y /= np.linalg.norm(y, axis=0)\n",
+    "x = np.cross(y, z, axis=0)\n",
+    "cos_theta = np.sum(n * z, axis=0)\n",
+    "z_cross_n = np.cross(z, n, axis=0)\n",
+    "cos_phi = np.sum(y * z_cross_n, axis=0) / np.linalg.norm(z_cross_n, axis=0)\n",
+    "sin_phi = -np.sum(x * z_cross_n, axis=0) / np.linalg.norm(z_cross_n, axis=0)\n",
+    "phi_adair = np.arctan2(sin_phi, cos_phi)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 4, tight_layout=True, figsize=(13, 4))\n",
-    "\n",
-    "ax[0].hist(cosTheta, bins=50, color=\"aqua\", alpha=0.33)\n",
+    "ax[0].hist(cos_theta, bins=50, color=\"aqua\", alpha=0.33)\n",
     "ax[0].set_xlabel(\"cos(theta)\")\n",
     "ax[0].set_ylabel(\"Entries/0.01\")\n",
-    "ax[1].hist(cosPhi, color=\"lightskyblue\", bins=50, alpha=0.33)\n",
+    "ax[1].hist(cos_phi, color=\"lightskyblue\", bins=50, alpha=0.33)\n",
     "ax[1].set_xlabel(\"$\\cos\\phi$\")\n",
     "ax[1].set_ylabel(\"Entries/0.01\")\n",
-    "ax[2].hist(sinPhi, bins=50, color=\"slateblue\", alpha=0.33)\n",
+    "ax[2].hist(sin_phi, bins=50, color=\"slateblue\", alpha=0.33)\n",
     "ax[2].set_xlabel(\"$\\sin\\phi$\")\n",
     "ax[2].set_ylabel(\"Entries/0.01\")\n",
-    "ax[3].hist(phiAdair, bins=50, color=\"darkorchid\", alpha=0.33)\n",
+    "ax[3].hist(phi_adair, bins=50, color=\"darkorchid\", alpha=0.33)\n",
     "ax[3].set_xlabel(\"$\\phi_{Adair}$ [rad]\")\n",
-    "ax[3].set_ylabel(\"Entries/(0.13 rad)\")"
+    "ax[3].set_ylabel(\"Entries/(0.13 rad)\")\n",
+    "plt.show()"
    ]
   }
  ],

--- a/lecture12d-phasespace.ipynb
+++ b/lecture12d-phasespace.ipynb
@@ -4,17 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lecture 12 – Phase space simulation\n",
-    "\n",
-    "**How to perform a phase space simulation**"
+    "# Lecture 12 – Phase space simulation"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Prepare the notebook with the preambles for the inclusion of pandas, numpy and matplotlib.pyplot.\n",
-    "Import the data file (csv format) into Google Colab through the drive.mount command, import the pylorentz package."
+    "**How to perform a phase space simulation with Python?**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Prepare the notebook by importing [`pandas`](https://pandas.pydata.org), [`numpy`](https://numpy.org), [`matplotlib.pyplot`](https://matplotlib.org/3.5.3/api/_as_gen/matplotlib.pyplot.html), and [`pylorentz`](https://github.com/PyLorentz/PyLorentz) and download the data file (CSV format) from Google Drive."
    ]
   },
   {
@@ -33,12 +37,52 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"3\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "mystnb": {
+     "code_prompt_show": "Import Python libraries"
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "import phasespace\n",
+    "import tensorflow as tf\n",
+    "from pylorentz import Momentum4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Two-body decay"
    ]
   },
   {
@@ -54,23 +98,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import phasespace\n",
-    "\n",
     "B0_MASS = 5279.65\n",
     "PION_MASS = 139.57018\n",
     "KAON_MASS = 493.677\n",
-    "numberOfEvents = 10000\n",
+    "n_events = 100_000\n",
     "\n",
-    "weights, particles = phasespace.nbody_decay(B0_MASS, [PION_MASS, KAON_MASS]).generate(\n",
-    "    n_events=numberOfEvents\n",
-    ")"
+    "decay = phasespace.nbody_decay(B0_MASS, [PION_MASS, KAON_MASS])\n",
+    "weights, four_momenta = decay.generate(n_events=n_events)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The simulation produces a dictionary (particles) of TensorFlow objects. Each object can be addresses with particles ['p_i'], where \"i\" is the number of the i-th generated particle."
+    "The simulation produces a dictionary (`four_momenta`) of [`tf.Tensor`](https://www.tensorflow.org/api_docs/python/tf/Tensor) objects. Each object can be addressed with `particles['p_i']`, where `i` is the number of the $i$-th generated particle."
    ]
   },
   {
@@ -79,23 +120,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "particles"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "particles[\"p_0\"]"
+    "four_momenta"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each TensorFlow object is a numpy.array: it can be saved in a tf object with a given name, and the component can be extracted as elements of np.arrays"
+    "Each [`tf.Tensor`](https://www.tensorflow.org/api_docs/python/tf/Tensor) can be converted to a NumPy array, which can then be converted to a [`pylorentz`](https://github.com/PyLorentz/PyLorentz)."
    ]
   },
   {
@@ -104,8 +136,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "piontf = particles[\"p_0\"]\n",
-    "kaontf = particles[\"p_1\"]"
+    "def to_lorentz(p: tf.Tensor) -> Momentum4:\n",
+    "    p = p.numpy().T\n",
+    "    return Momentum4(p[3], *p[:3])"
    ]
   },
   {
@@ -114,20 +147,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(piontf.numpy())\n",
-    "print(\" \")\n",
-    "# extract a single component of one of the particles objects\n",
-    "print(np.array(piontf[1][1]))\n",
-    "print(\" \")\n",
-    "# to extract one column\n",
-    "print(np.array(piontf[:, 1]))"
+    "pion = to_lorentz(four_momenta[\"p_0\"])\n",
+    "kaon = to_lorentz(four_momenta[\"p_1\"])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One can now prepare pylorentz objects to make kinematic calculations with 4-vectors:"
+    "These objects can be used to do kinematic computations. Let's first verify that the invariant mass of the kaon+pion system corresponds to the mass of the mother $B^0$:"
    ]
   },
   {
@@ -136,81 +164,73 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import math\n",
-    "\n",
-    "from pylorentz import Momentum4"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "kaonpx = np.array(kaontf[:, 0])\n",
-    "kaonpy = np.array(kaontf[:, 1])\n",
-    "kaonpz = np.array(kaontf[:, 2])\n",
-    "pKT = np.sqrt(kaonpx**2 + kaonpy**2)\n",
-    "pKmod = np.sqrt(pKT**2 + kaonpz**2)\n",
-    "etaK = np.arcsinh(kaonpz / pKT)\n",
-    "phiK = np.arctan2(kaonpy, kaonpx)\n",
-    "EK = np.array(kaontf[:, 3])\n",
-    "kaon = Momentum4.e_eta_phi_p(EK, etaK, phiK, pKmod)\n",
-    "\n",
-    "pPiT = np.sqrt((np.array(piontf[:, 0])) ** 2 + (np.array(piontf[:, 1])) ** 2)\n",
-    "pPimod = np.sqrt(pPiT**2 + (np.array(piontf[:, 2])) ** 2)\n",
-    "etaPi = np.arcsinh(np.array(piontf[:, 2]) / pPiT)\n",
-    "phiPi = np.arctan2(np.array(piontf[:, 1]), np.array(piontf[:, 0]))\n",
-    "pion = Momentum4.e_eta_phi_p(np.array(piontf[:, 3]), etaPi, phiPi, pPimod)\n",
-    "\n",
-    "# the mother (B0) is at rest\n",
-    "EB0 = B0_MASS * np.ones(numberOfEvents)\n",
-    "etaB0 = np.zeros(numberOfEvents)\n",
-    "phiB0 = np.zeros(numberOfEvents)\n",
-    "pB0 = np.zeros(numberOfEvents)\n",
-    "B0mother = Momentum4.e_eta_phi_p(EB0, etaB0, phiB0, pB0)"
+    "B0 = pion + kaon\n",
+    "np.testing.assert_almost_equal(B0.m.mean(), B0_MASS)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's verify that the invariant mass of the kaon+pion system corresponds to the mass of the mother $B^0$. Let's plot also the momentum components of the two daugther particles."
+    "Let's also plot the momentum components of the two daugther particles."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input",
+     "full-width",
+     "scroll-input"
+    ]
+   },
    "outputs": [],
    "source": [
-    "invariantMassKP = kaon + pion\n",
-    "\n",
     "fig, ax = plt.subplots(1, 4, tight_layout=True, figsize=(11, 3.5))\n",
-    "ax[0].hist(invariantMassKP.m, bins=100, color=\"CornFlowerBlue\", range=(5279, 5280))\n",
+    "ax[0].hist(B0.m, bins=100, color=\"CornFlowerBlue\", range=(5279, 5280))\n",
     "ax[0].set_xlabel(\"i.m.($\\pi$K) [MeV/$c^2$]\")\n",
     "ax[0].set_title(\"(pion-kaon) i.m. \\n\")\n",
     "\n",
     "ax[1].hist(kaon.p_x, bins=70, color=\"lightcoral\", hatch=\"//\")\n",
     "ax[1].hist(\n",
-    "    pion.p_x, bins=70, color=\"springgreen\", histtype=\"barstacked\", hatch=\"\\\\\", alpha=0.5\n",
+    "    pion.p_x,\n",
+    "    bins=70,\n",
+    "    color=\"springgreen\",\n",
+    "    histtype=\"barstacked\",\n",
+    "    hatch=\"\\\\\",\n",
+    "    alpha=0.5,\n",
     ")\n",
     "ax[1].set_xlabel(\"$p_x$ [MeV/$c$]\")\n",
     "ax[1].set_title(\"x mom. component \\n\")\n",
     "\n",
     "ax[2].hist(kaon.p_y, bins=70, color=\"lightcoral\", hatch=\"//\")\n",
     "ax[2].hist(\n",
-    "    pion.p_y, bins=70, color=\"springgreen\", histtype=\"barstacked\", hatch=\"\\\\\", alpha=0.5\n",
+    "    pion.p_y,\n",
+    "    bins=70,\n",
+    "    color=\"springgreen\",\n",
+    "    histtype=\"barstacked\",\n",
+    "    hatch=\"\\\\\",\n",
+    "    alpha=0.5,\n",
     ")\n",
     "ax[2].set_xlabel(\"$p_y$ [MeV/$c$]\")\n",
     "ax[2].set_title(\"y mom. component \\n\")\n",
     "\n",
     "ax[3].hist(kaon.p_z, bins=70, color=\"lightcoral\", hatch=\"//\")\n",
     "ax[3].hist(\n",
-    "    pion.p_z, bins=70, color=\"springgreen\", histtype=\"barstacked\", hatch=\"\\\\\", alpha=0.5\n",
+    "    pion.p_z,\n",
+    "    bins=70,\n",
+    "    color=\"springgreen\",\n",
+    "    histtype=\"barstacked\",\n",
+    "    hatch=\"\\\\\",\n",
+    "    alpha=0.5,\n",
     ")\n",
     "ax[3].set_xlabel(\"$p_z$ [MeV/$c$]\")\n",
-    "ax[3].set_title(\"z mom. component \\n\")"
+    "ax[3].set_title(\"z mom. component \\n\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -224,11 +244,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "\n",
-    "---\n",
-    "\n",
-    "\n"
+    "## Three-body decay"
    ]
   },
   {
@@ -245,11 +261,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "numberOfEvents = 50000\n",
+    "n_events = 50_000\n",
     "PION0_MASS = 134.9766\n",
-    "weights, particles = phasespace.nbody_decay(\n",
-    "    B0_MASS, [PION_MASS, PION0_MASS, KAON_MASS]\n",
-    ").generate(n_events=numberOfEvents)"
+    "decay = phasespace.nbody_decay(B0_MASS, [PION_MASS, PION0_MASS, KAON_MASS])\n",
+    "weights, four_momenta = decay.generate(n_events=n_events)"
    ]
   },
   {
@@ -258,83 +273,58 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "piontf = particles[\"p_0\"]\n",
-    "pion0tf = particles[\"p_1\"]\n",
-    "kaontf = particles[\"p_2\"]\n",
-    "\n",
-    "kaonpx = np.array(kaontf[:, 0])\n",
-    "kaonpy = np.array(kaontf[:, 1])\n",
-    "kaonpz = np.array(kaontf[:, 2])\n",
-    "pKT = np.sqrt(kaonpx**2 + kaonpy**2)\n",
-    "pKmod = np.sqrt(pKT**2 + kaonpz**2)\n",
-    "etaK = np.arcsinh(kaonpz / pKT)\n",
-    "phiK = np.arctan2(kaonpy, kaonpx)\n",
-    "EK = np.array(kaontf[:, 3])\n",
-    "kaon = Momentum4.e_eta_phi_p(EK, etaK, phiK, pKmod)\n",
-    "\n",
-    "pPiT = np.sqrt((np.array(piontf[:, 0])) ** 2 + (np.array(piontf[:, 1])) ** 2)\n",
-    "pPimod = np.sqrt(pPiT**2 + (np.array(piontf[:, 2])) ** 2)\n",
-    "etaPi = np.arcsinh(np.array(piontf[:, 2]) / pPiT)\n",
-    "phiPi = np.arctan2(np.array(piontf[:, 1]), np.array(piontf[:, 0]))\n",
-    "pion = Momentum4.e_eta_phi_p(np.array(piontf[:, 3]), etaPi, phiPi, pPimod)\n",
-    "\n",
-    "pPi0T = np.sqrt((np.array(pion0tf[:, 0])) ** 2 + (np.array(pion0tf[:, 1])) ** 2)\n",
-    "pPi0mod = np.sqrt(pPi0T**2 + (np.array(pion0tf[:, 2])) ** 2)\n",
-    "etaPi0 = np.arcsinh(np.array(pion0tf[:, 2]) / pPi0T)\n",
-    "phiPi0 = np.arctan2(np.array(pion0tf[:, 1]), np.array(pion0tf[:, 0]))\n",
-    "pion0 = Momentum4.e_eta_phi_p(np.array(pion0tf[:, 3]), etaPi0, phiPi0, pPi0mod)\n",
-    "\n",
-    "\n",
-    "# the mother (B0) is at rest\n",
-    "EB0 = B0_MASS * np.ones(numberOfEvents)\n",
-    "etaB0 = np.zeros(numberOfEvents)\n",
-    "phiB0 = np.zeros(numberOfEvents)\n",
-    "pB0 = np.zeros(numberOfEvents)\n",
-    "B0mother = Momentum4.e_eta_phi_p(EB0, etaB0, phiB0, pB0)"
+    "pim = to_lorentz(four_momenta[\"p_0\"])\n",
+    "pi0 = to_lorentz(four_momenta[\"p_1\"])\n",
+    "kaon = to_lorentz(four_momenta[\"p_2\"])\n",
+    "s1 = (kaon + pim).m2\n",
+    "s2 = (kaon + pi0).m2\n",
+    "s3 = (pim + pi0).m2"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input",
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
-    "invariantMassKP = kaon + pion\n",
-    "invariantMassKPi0 = kaon + pion0\n",
-    "invariantMass2Pi = pion + pion0\n",
-    "\n",
     "fig, ax = plt.subplots(1, 3, tight_layout=True, figsize=(12, 3.5))\n",
-    "f0 = ax[0].hist2d(invariantMassKP.m2, invariantMass2Pi.m2, bins=70, cmap=\"turbo\")\n",
+    "f0 = ax[0].hist2d(s1, s3, bins=70, cmap=\"turbo\", cmin=1)\n",
     "fig.colorbar(f0[3], ax=ax[0])\n",
     "ax[0].set_xlabel(\"i.m.$^2(\\pi^-K^+)$ [(MeV/$c^2)^2]$\")\n",
     "ax[0].set_ylabel(\"i.m.$^2(\\pi^-\\pi^0)$ [(MeV/$c^2)^2]$\")\n",
     "\n",
-    "f1 = ax[1].hist2d(invariantMassKPi0.m2, invariantMass2Pi.m2, bins=70, cmap=\"turbo\")\n",
+    "f1 = ax[1].hist2d(s2, s3, bins=70, cmap=\"turbo\", cmin=1)\n",
     "fig.colorbar(f1[3], ax=ax[1])\n",
     "ax[1].set_xlabel(\"i.m.$^2(\\pi^0K^+)$ [(MeV/$c^2)^2]$\")\n",
     "ax[1].set_ylabel(\"i.m.$^2(\\pi^-\\pi^0)$ [(MeV/$c^2)^2]$\")\n",
     "\n",
-    "f2 = ax[2].hist2d(invariantMassKP.m2, invariantMassKPi0.m2, bins=70, cmap=\"turbo\")\n",
+    "f2 = ax[2].hist2d(s1, s2, bins=70, cmap=\"turbo\", cmin=1)\n",
     "fig.colorbar(f2[3], ax=ax[2])\n",
     "ax[2].set_xlabel(\"i.m.$^2(\\pi^-K^+)$ [(MeV/$c^2)^2]$\")\n",
-    "ax[2].set_ylabel(\"i.m.$^2(\\pi^0K^+)$ [(MeV/$c^2)^2]$\")"
+    "ax[2].set_ylabel(\"i.m.$^2(\\pi^0K^+)$ [(MeV/$c^2)^2]$\")\n",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "\n",
-    "---\n",
-    "\n"
+    "## Decay chain"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The package *phasespace* allows to treat also multiple decays. Let's consider the $B^0\\rightarrow K^{\\ast 0}\\gamma$ decay, followed by $K^{\\ast 0}\\rightarrow \\pi^-K^+$. It can be simulated using the following procedure:"
+    "The [`phasespace`](https://phasespace.rtfd.io) package allows to treat also multiple decays. Let's consider the $B^0\\rightarrow K^{\\ast 0}\\gamma$ decay, followed by $K^{\\ast 0}\\rightarrow \\pi^-K^+$. It can be simulated using the following procedure:"
    ]
   },
   {
@@ -346,19 +336,18 @@
     "from phasespace import GenParticle\n",
     "\n",
     "B0_MASS = 5279.65\n",
-    "KSTARZ_MASS = 895.55\n",
+    "K0STAR_MASS = 895.55\n",
     "PION_MASS = 139.57018\n",
     "KAON_MASS = 493.677\n",
     "GAMMA_MASS = 0.0\n",
-    "numberOfEvents = 20000\n",
     "\n",
-    "kaonPlus = GenParticle(\"K+\", KAON_MASS)\n",
-    "pionMinus = GenParticle(\"pi-\", PION_MASS)\n",
-    "kstarZero = GenParticle(\"KStar\", KSTARZ_MASS).set_children(kaonPlus, pionMinus)\n",
+    "Kp = GenParticle(\"K+\", KAON_MASS)\n",
+    "pim = GenParticle(\"pi-\", PION_MASS)\n",
+    "Kstar = GenParticle(\"KStar\", K0STAR_MASS).set_children(Kp, pim)\n",
     "gamma = GenParticle(\"gamma\", GAMMA_MASS)\n",
-    "bZero = GenParticle(\"B0\", B0_MASS).set_children(kstarZero, gamma)\n",
+    "B0 = GenParticle(\"B0\", B0_MASS).set_children(Kstar, gamma)\n",
     "\n",
-    "weights, particles = bZero.generate(n_events=numberOfEvents)"
+    "weights, four_momenta = B0.generate(n_events=100_000)"
    ]
   },
   {
@@ -367,7 +356,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "particles"
+    "four_momenta"
    ]
   },
   {
@@ -376,50 +365,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# import tfTensors and store kinematics in pylorentz 4-momenta\n",
-    "piontf = particles[\"pi-\"]\n",
-    "gammatf = particles[\"gamma\"]\n",
-    "kaontf = particles[\"K+\"]\n",
-    "kaonStartf = particles[\"KStar\"]\n",
-    "\n",
-    "kaonpx = np.array(kaontf[:, 0])\n",
-    "kaonpy = np.array(kaontf[:, 1])\n",
-    "kaonpz = np.array(kaontf[:, 2])\n",
-    "pKT = np.sqrt(kaonpx**2 + kaonpy**2)\n",
-    "pKmod = np.sqrt(pKT**2 + kaonpz**2)\n",
-    "etaK = np.arcsinh(kaonpz / pKT)\n",
-    "phiK = np.arctan2(kaonpy, kaonpx)\n",
-    "EK = np.array(kaontf[:, 3])\n",
-    "kaon = Momentum4.e_eta_phi_p(EK, etaK, phiK, pKmod)\n",
-    "\n",
-    "pPiT = np.sqrt((np.array(piontf[:, 0])) ** 2 + (np.array(piontf[:, 1])) ** 2)\n",
-    "pPimod = np.sqrt(pPiT**2 + (np.array(piontf[:, 2])) ** 2)\n",
-    "etaPi = np.arcsinh(np.array(piontf[:, 2]) / pPiT)\n",
-    "phiPi = np.arctan2(np.array(piontf[:, 1]), np.array(piontf[:, 0]))\n",
-    "pion = Momentum4.e_eta_phi_p(np.array(piontf[:, 3]), etaPi, phiPi, pPimod)\n",
-    "\n",
-    "pgammaT = np.sqrt((np.array(gammatf[:, 0])) ** 2 + (np.array(gammatf[:, 1])) ** 2)\n",
-    "pgammamod = np.sqrt(pgammaT**2 + (np.array(gammatf[:, 2])) ** 2)\n",
-    "etagamma = np.arcsinh(np.array(gammatf[:, 2]) / pgammaT)\n",
-    "phigamma = np.arctan2(np.array(gammatf[:, 1]), np.array(gammatf[:, 0]))\n",
-    "gamma = Momentum4.e_eta_phi_p(np.array(gammatf[:, 3]), etagamma, phigamma, pgammamod)\n",
-    "\n",
-    "pkaonStarT = np.sqrt(\n",
-    "    (np.array(kaonStartf[:, 0])) ** 2 + (np.array(kaonStartf[:, 1])) ** 2\n",
-    ")\n",
-    "pkaonStarmod = np.sqrt(pkaonStarT**2 + (np.array(kaonStartf[:, 2])) ** 2)\n",
-    "etakaonStar = np.arcsinh(np.array(kaonStartf[:, 2]) / pkaonStarT)\n",
-    "phikaonStar = np.arctan2(np.array(kaonStartf[:, 1]), np.array(kaonStartf[:, 0]))\n",
-    "kaonStar = Momentum4.e_eta_phi_p(\n",
-    "    np.array(kaonStartf[:, 3]), etakaonStar, phikaonStar, pkaonStarmod\n",
-    ")\n",
-    "\n",
-    "# the mother (B0) is at rest\n",
-    "EB0 = B0_MASS * np.ones(numberOfEvents)\n",
-    "etaB0 = np.zeros(numberOfEvents)\n",
-    "phiB0 = np.zeros(numberOfEvents)\n",
-    "pB0 = np.zeros(numberOfEvents)\n",
-    "B0mother = Momentum4.e_eta_phi_p(EB0, etaB0, phiB0, pB0)"
+    "gamma = to_lorentz(four_momenta[\"gamma\"])\n",
+    "pion = to_lorentz(four_momenta[\"pi-\"])\n",
+    "kaon = to_lorentz(four_momenta[\"K+\"])\n",
+    "Kstar = to_lorentz(four_momenta[\"KStar\"])"
    ]
   },
   {
@@ -435,126 +384,115 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "invariantMassKP = kaon + pion\n",
-    "invariantMassKGamma = kaon + gamma\n",
-    "invariantMassPiGamma = pion + gamma\n",
-    "s = (kaon + pion + gamma).m2\n",
-    "diffMass = B0mother.e - np.sqrt(s)\n",
-    "\n",
+    "s1 = (pion + kaon).m2\n",
+    "s2 = (gamma + kaon).m2\n",
+    "s3 = (gamma + pion).m2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input",
+     "full-width"
+    ]
+   },
+   "outputs": [],
+   "source": [
     "fig, ax = plt.subplots(1, 3, tight_layout=True, figsize=(12, 3.5))\n",
-    "f0 = ax[0].hist2d(invariantMassKP.m2, invariantMassKGamma.m2, bins=70, cmap=\"rainbow\")\n",
+    "\n",
+    "f0 = ax[0].hist2d(s1, s2, bins=70, cmap=\"turbo\")\n",
     "fig.colorbar(f0[3], ax=ax[0])\n",
     "ax[0].set_xlabel(\"i.m.$^2(\\pi^-K^+)$ [(MeV/$c^2)^2]$\")\n",
     "ax[0].set_ylabel(\"i.m.$^2(K^+\\gamma)$ [(MeV/$c^2)^2]$\")\n",
     "\n",
-    "f1 = ax[1].hist2d(\n",
-    "    invariantMassKGamma.m2, invariantMassPiGamma.m2, bins=70, cmap=\"rainbow\"\n",
-    ")\n",
+    "f1 = ax[1].hist2d(s2, s3, bins=70, cmap=\"turbo\")\n",
     "fig.colorbar(f1[3], ax=ax[1])\n",
-    "# f1 = ax[1].hist(invariantMassPiGamma.m, bins=70)\n",
     "ax[1].set_xlabel(\"i.m.$^2(K^+\\gamma)$ [(MeV/$c^2)^2]$\")\n",
     "ax[1].set_ylabel(\"i.m.$^2(\\pi^-\\gamma)$ [(MeV/$c^2)^2]$\")\n",
     "\n",
-    "f2 = ax[2].hist2d(invariantMassKP.m2, invariantMassPiGamma.m2, bins=70, cmap=\"rainbow\")\n",
+    "f2 = ax[2].hist2d(s1, s3, bins=70, cmap=\"turbo\")\n",
     "fig.colorbar(f2[3], ax=ax[2])\n",
     "ax[2].set_xlabel(\"i.m.$^2(\\pi^-K^+)$ [(MeV/$c^2)^2]$\")\n",
     "ax[2].set_ylabel(\"i.m.$^2(\\pi^-\\gamma)$ [(MeV/$c^2)^2]$\")\n",
-    "\n",
-    "diffMass"
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's simulate a more realistic $K^\\ast$ particle, not monochromatic but with a width of 47 MeV. The mass is extracted from a Gaussian distribution centered at the B0_MASS value and with $\\sigma = 47/2.36 \\sim 20$ MeV.\n",
-    "Ideally, one would simulate a big number of events but for the purpose of this exercise we need to keep this number as small as possible (say < 1000). You can try with larger numbers offline, though.  "
+    "### Width distribution"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# extract the mass value from a gaussian distribution\n",
-    "# keep the number small (much smaller than 1000!), the simulation iterated event by event takes very long\n",
-    "numberOfEvents = 500\n",
-    "# do you remember the difference between a BW sigma and a lorentzian FWHM?\n",
-    "# the widths you get out of the PDG booklet are FWHM's\n",
-    "sigmaKStar = (\n",
-    "    47 / 2.36\n",
-    ")  # do you remember the difference between a BW sigma and a lorentzian FWHM?\n",
-    "KStarResonanceMass = np.random.normal(KSTARZ_MASS, sigmaKStar, numberOfEvents)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "kaonPlus = GenParticle(\"K+\", KAON_MASS)\n",
-    "pionMinus = GenParticle(\"pi-\", PION_MASS)\n",
-    "invMassKP = []\n",
-    "invMassKGamma = []\n",
-    "invMassPiGamma = []\n",
+    "These distributions aren't so interesting, because the masses of each particle are one fixed value. So let's simulate a more realistic $K^\\ast$ particle; not monochromatic, but with a width of 47 MeV.[^1] The mass is extracted from a Gaussian distribution centered at the B0_MASS value and with $\\sigma = 47/2.36 \\sim 20$ MeV. See more info on how to do this with the `phasespace` package [here](https://phasespace.readthedocs.io/en/1.9.0/usage.html#resonances-with-variable-mass).\n",
     "\n",
-    "for i in range(numberOfEvents):\n",
-    "    #     kaonPlus = GenParticle('K+', KAON_MASS)\n",
-    "    #     pionMinus = GenParticle('pi-', PION_MASS)\n",
-    "    kstarZero = GenParticle(\"KStar\", KStarResonanceMass[i]).set_children(\n",
-    "        kaonPlus, pionMinus\n",
-    "    )\n",
-    "    gamma = GenParticle(\"gamma\", GAMMA_MASS)\n",
-    "    bZero = GenParticle(\"B0\", B0_MASS).set_children(kstarZero, gamma)\n",
-    "    weights, particles = bZero.generate(n_events=1)\n",
-    "    piontf = particles[\"pi-\"]\n",
-    "    # kinematics\n",
-    "    gammatf = particles[\"gamma\"]\n",
-    "    kaontf = particles[\"K+\"]\n",
-    "    kaonStartf = particles[\"KStar\"]\n",
-    "    kaonpx = np.array(kaontf[:, 0])\n",
-    "    kaonpy = np.array(kaontf[:, 1])\n",
-    "    kaonpz = np.array(kaontf[:, 2])\n",
-    "    pKT = np.sqrt(kaonpx**2 + kaonpy**2)\n",
-    "    pKmod = np.sqrt(pKT**2 + kaonpz**2)\n",
-    "    etaK = np.arcsinh(kaonpz / pKT)\n",
-    "    phiK = np.arctan2(kaonpy, kaonpx)\n",
-    "    EK = np.array(kaontf[:, 3])\n",
-    "    kaon = Momentum4.e_eta_phi_p(EK, etaK, phiK, pKmod)\n",
-    "    pPiT = np.sqrt((np.array(piontf[:, 0])) ** 2 + (np.array(piontf[:, 1])) ** 2)\n",
-    "    pPimod = np.sqrt(pPiT**2 + (np.array(piontf[:, 2])) ** 2)\n",
-    "    etaPi = np.arcsinh(np.array(piontf[:, 2]) / pPiT)\n",
-    "    phiPi = np.arctan2(np.array(piontf[:, 1]), np.array(piontf[:, 0]))\n",
-    "    pion = Momentum4.e_eta_phi_p(np.array(piontf[:, 3]), etaPi, phiPi, pPimod)\n",
-    "    pgammaT = np.sqrt((np.array(gammatf[:, 0])) ** 2 + (np.array(gammatf[:, 1])) ** 2)\n",
-    "    pgammamod = np.sqrt(pgammaT**2 + (np.array(gammatf[:, 2])) ** 2)\n",
-    "    etagamma = np.arcsinh(np.array(gammatf[:, 2]) / pgammaT)\n",
-    "    phigamma = np.arctan2(np.array(gammatf[:, 1]), np.array(gammatf[:, 0]))\n",
-    "    gamma = Momentum4.e_eta_phi_p(\n",
-    "        np.array(gammatf[:, 3]), etagamma, phigamma, pgammamod\n",
-    "    )\n",
-    "    pkaonStarT = np.sqrt(\n",
-    "        (np.array(kaonStartf[:, 0])) ** 2 + (np.array(kaonStartf[:, 1])) ** 2\n",
-    "    )\n",
-    "    pkaonStarmod = np.sqrt(pkaonStarT**2 + (np.array(kaonStartf[:, 2])) ** 2)\n",
-    "    etakaonStar = np.arcsinh(np.array(kaonStartf[:, 2]) / pkaonStarT)\n",
-    "    phikaonStar = np.arctan2(np.array(kaonStartf[:, 1]), np.array(kaonStartf[:, 0]))\n",
-    "    kaonStar = Momentum4.e_eta_phi_p(\n",
-    "        np.array(kaonStartf[:, 3]), etakaonStar, phikaonStar, pkaonStarmod\n",
-    "    )\n",
-    "    # the mother (B0) is at rest\n",
-    "    EB0 = B0_MASS * np.ones(numberOfEvents)\n",
-    "    etaB0 = np.zeros(numberOfEvents)\n",
-    "    phiB0 = np.zeros(numberOfEvents)\n",
-    "    pB0 = np.zeros(numberOfEvents)\n",
-    "    B0mother = Momentum4.e_eta_phi_p(EB0, etaB0, phiB0, pB0)\n",
-    "    # print((kaon+pion).m2)\n",
-    "    # invariant masses arrays\n",
-    "    invMassKP.append((kaon + pion).m2)\n",
-    "    invMassKGamma.append((kaon + gamma).m2)\n",
-    "    invMassPiGamma.append((pion + gamma).m2)"
+    "[^1]: Do you remember the difference between a BW width and a Lorentzian FWHM? The widths you get out of the PDG booklet are FWHM's."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import tensorflow_probability as tfp\n",
+    "\n",
+    "K0STAR_WIDTH = 47 / 2.36\n",
+    "\n",
+    "\n",
+    "def kstar_mass(min_mass, max_mass, n_events):\n",
+    "    min_mass = tf.cast(min_mass, tf.float64)\n",
+    "    max_mass = tf.cast(max_mass, tf.float64)\n",
+    "    kstar_mass_cast = tf.cast(K0STAR_MASS, dtype=tf.float64)\n",
+    "    kstar_width_cast = tf.cast(K0STAR_WIDTH, tf.float64)\n",
+    "    kstar_mass = tf.broadcast_to(kstar_mass_cast, shape=(n_events,))\n",
+    "    return tfp.distributions.TruncatedNormal(\n",
+    "        loc=K0STAR_MASS,\n",
+    "        scale=K0STAR_WIDTH,\n",
+    "        low=min_mass,\n",
+    "        high=max_mass,\n",
+    "    ).sample()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K = GenParticle(\"K+\", KAON_MASS)\n",
+    "pion = GenParticle(\"pi-\", PION_MASS)\n",
+    "Kstar = GenParticle(\"KStar\", kstar_mass).set_children(K, pion)\n",
+    "gamma = GenParticle(\"gamma\", GAMMA_MASS)\n",
+    "B0 = GenParticle(\"B0\", B0_MASS).set_children(Kstar, gamma)\n",
+    "weights, four_momenta = B0.generate(n_events=100_000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gamma = to_lorentz(four_momenta[\"gamma\"])\n",
+    "pion = to_lorentz(four_momenta[\"pi-\"])\n",
+    "kaon = to_lorentz(four_momenta[\"K+\"])\n",
+    "Kstar = to_lorentz(four_momenta[\"KStar\"])"
    ]
   },
   {
@@ -570,49 +508,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "im1 = np.array(invMassKP)\n",
-    "im2 = np.array(invMassKGamma)\n",
-    "im3 = np.array(invMassPiGamma)"
+    "s1 = (pion + kaon).m2\n",
+    "s2 = (gamma + kaon).m2\n",
+    "s3 = (gamma + pion).m2"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-input",
+     "full-width"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 3, tight_layout=True, figsize=(12, 3.5))\n",
-    "# f0 = ax[0].hist2d(np.array(invMassKP), np.array(invMassKGamma), bins=70, cmap='rainbow')\n",
-    "f0 = ax[0].hist2d(im1[:, 0], im2[:, 0], bins=70, cmap=\"rainbow\")\n",
+    "f0 = ax[0].hist2d(s1, s2, bins=70, cmap=\"rainbow\")\n",
     "fig.colorbar(f0[3], ax=ax[0])\n",
     "ax[0].set_xlabel(\"i.m.$^2(\\pi^-K^+)$ [(MeV/$c^2)^2]$\")\n",
     "ax[0].set_ylabel(\"i.m.$^2(K^+\\gamma)$ [(MeV/$c^2)^2]$\")\n",
     "\n",
-    "f1 = ax[1].hist2d(\n",
-    "    np.array(invMassKGamma)[:, 0],\n",
-    "    np.array(invMassPiGamma)[:, 0],\n",
-    "    bins=70,\n",
-    "    cmap=\"rainbow\",\n",
-    ")\n",
+    "f1 = ax[1].hist2d(s2, s3, bins=70, cmap=\"rainbow\")\n",
     "fig.colorbar(f1[3], ax=ax[1])\n",
-    "# f1 = ax[1].hist(invariantMassPiGamma.m, bins=70)\n",
     "ax[1].set_xlabel(\"i.m.$^2(K^+\\gamma)$ [(MeV/$c^2)^2]$\")\n",
     "ax[1].set_ylabel(\"i.m.$^2(\\pi^-\\gamma)$ [(MeV/$c^2)^2]$\")\n",
     "\n",
-    "f2 = ax[2].hist2d(\n",
-    "    np.array(invMassKP)[:, 0], np.array(invMassPiGamma)[:, 0], bins=70, cmap=\"rainbow\"\n",
-    ")\n",
+    "f2 = ax[2].hist2d(s1, s3, bins=70, cmap=\"rainbow\")\n",
     "fig.colorbar(f2[3], ax=ax[2])\n",
     "ax[2].set_xlabel(\"i.m.$^2(\\pi^-K^+)$ [(MeV/$c^2)^2]$\")\n",
-    "ax[2].set_ylabel(\"i.m.$^2(\\pi^-\\gamma)$ [(MeV/$c^2)^2]$\")"
+    "ax[2].set_ylabel(\"i.m.$^2(\\pi^-\\gamma)$ [(MeV/$c^2)^2]$\")\n",
+    "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/lecture12e-longitudinal.ipynb
+++ b/lecture12e-longitudinal.ipynb
@@ -31,30 +31,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "mystnb": {
+     "code_prompt_show": "Import Python libraries"
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
    "outputs": [],
    "source": [
+    "import math\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from pylorentz import Momentum4"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import gdown\n",
-    "\n",
-    "# real experimental data\n",
-    "# gammap_5GeV_PiPlusPiMinusProtWHel_gold2bG14.csv\n",
-    "\n",
-    "# Montecarlo generated data\n",
-    "# gen_gammap5GeV_PipPimP.csv\n",
-    "# url = 'https://drive.google.com/uc?id=11J0xaQLRMxzgQLXEhXZb_u4mnxp8RVPO'\n",
-    "# gen_gammap10GeV_PipPimP.csv\n",
-    "# url = 'https://drive.google.com/uc?id=1U_1bE3k2vT-uZwnmAgU9OVCku7oZjsMA'\n",
     "\n",
     "output_path = gdown.cached_download(\n",
     "    url=\"https://drive.google.com/uc?id=1VkG1gYY4qnfqNz3MEUkOKDwcAW4EF4uR\",\n",
@@ -62,27 +71,9 @@
     "    md5=\"6aa2ab1388aa7fc1ce0568e3e972e491\",\n",
     "    quiet=True,\n",
     ")\n",
-    "data = pd.read_csv(output_path)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import math\n",
-    "\n",
-    "from pylorentz import Momentum4"
+    "data = pd.read_csv(output_path)\n",
+    "data.columns = data.columns.str.strip()\n",
+    "data"
    ]
   },
   {
@@ -98,52 +89,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data.columns = data.columns.str.strip()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# final state\n",
-    "p1T = np.sqrt(data.p1x**2 + data.p1y**2)\n",
-    "p1mod = np.sqrt(p1T**2 + data.p1z**2)\n",
-    "eta1 = np.arcsinh(data.p1z / p1T)\n",
-    "phi1 = np.arctan2(data.p1y, data.p1x)\n",
-    "pionPlus = Momentum4.e_eta_phi_p(data.E1, eta1, phi1, p1mod)\n",
-    "\n",
-    "p2T = np.sqrt(data.p2x**2 + data.p2y**2)\n",
-    "p2mod = np.sqrt(p2T**2 + data.p2z**2)\n",
-    "eta2 = np.arcsinh(data.p2z / p2T)\n",
-    "phi2 = np.arctan2(data.p2y, data.p2x)\n",
-    "pionMinus = Momentum4.e_eta_phi_p(data.E2, eta2, phi2, p2mod)\n",
-    "\n",
-    "p3T = np.sqrt(data.p3x**2 + data.p3y**2)\n",
-    "p3mod = np.sqrt(p3T**2 + data.p3z**2)\n",
-    "eta3 = np.arcsinh(data.p3z / p3T)\n",
-    "phi3 = np.arctan2(data.p3y, data.p3x)\n",
-    "proton = Momentum4.e_eta_phi_p(data.E3, eta3, phi3, p3mod)\n",
+    "pip = Momentum4(data.E1, data.p1x, data.p1y, data.p1z)\n",
+    "pim = Momentum4(data.E2, data.p2x, data.p2y, data.p2z)\n",
+    "proton = Momentum4(data.E3, data.p3x, data.p3y, data.p3z)\n",
     "\n",
     "# initial state\n",
-    "# len is the number of events read by the csv file\n",
-    "len = data.pgamma.size\n",
-    "pgammaT = np.zeros(len)\n",
-    "pgammamod = data.pgamma\n",
-    "etagamma = 1.0e11 * np.ones(len)\n",
-    "phigamma = np.zeros(len)\n",
-    "massGamma = 0.0\n",
-    "Egamma = np.sqrt(massGamma**2 + pgammamod**2)\n",
-    "gamma = Momentum4.e_eta_phi_p(Egamma, etagamma, phigamma, pgammamod)\n",
-    "\n",
-    "# the target (proton) is at rest\n",
-    "massProton = 0.93827\n",
-    "ETgt = massProton * np.ones(len)\n",
-    "etaTgt = np.zeros(len)\n",
-    "phiTgt = np.zeros(len)\n",
-    "pTgt = np.zeros(len)\n",
-    "protonTarget = Momentum4.e_eta_phi_p(ETgt, etaTgt, phiTgt, pTgt)"
+    "n_events = len(data)\n",
+    "zeros = np.zeros(n_events)\n",
+    "ones = np.ones(n_events)\n",
+    "m_proton = 0.93827\n",
+    "gamma = Momentum4(data.pgamma, zeros, zeros, data.pgamma)\n",
+    "target = Momentum4(m_proton * ones, zeros, zeros, zeros)"
    ]
   },
   {
@@ -153,41 +110,41 @@
    "outputs": [],
    "source": [
     "# 4-momenta in the scenter of mass system\n",
-    "centerOfMass = gamma + protonTarget\n",
-    "\n",
-    "pionPlusCM = pionPlus.boost_particle(-centerOfMass)\n",
-    "pionMinusCM = pionMinus.boost_particle(-centerOfMass)\n",
-    "protonCM = proton.boost_particle(-centerOfMass)\n",
-    "\n",
-    "gammaCM = gamma.boost_particle(-centerOfMass)\n",
-    "protonTargetCM = protonTarget.boost_particle(-centerOfMass)"
+    "cm = gamma + target\n",
+    "pip_cm = pip.boost_particle(-cm)\n",
+    "pim_cm = pim.boost_particle(-cm)\n",
+    "proton_cm = proton.boost_particle(-cm)\n",
+    "gamma_cm = gamma.boost_particle(-cm)\n",
+    "target_cm = target.boost_particle(-cm)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A **longitudinal plot** (introduced for the first time by van Hove in 1969) offers a way to separate the contribution of different reaction production mechanisms. Inspecting a longitudinal plot may suggest particular selections in the longitudinal phase space which can help selecting specific reaction channels, enhancing for instance the contribution of meson versus baryon resonances.\n",
+    "A **longitudinal plot** (introduced for the first time [by Van Hove in 1969](https://doi.org/10.1016/0550-3213(69)90133-3)) offers a way to separate the contribution of different reaction production mechanisms. Inspecting a longitudinal plot may suggest particular selections in the longitudinal phase space which can help selecting specific reaction channels, enhancing for instance the contribution of meson versus baryon resonances.\n",
     "They are based on the assumption that at sufficiently high center-of-mass energies the phase space is reflected mainly by the longitudinal components of the particle momenta, while the transverse components can be neglected. Longitudinal plots are a convenient way to visualize the reaction kinematics of a reaction with three particles in the final state, in the form of 2D scattering plots (for $n$ particles in the final state, the reaction kinematics are visualized in a $(n-1)$ dimensional plane).\n",
     "For a reaction with a three particles final state one defines a set of polar coordinates $q$ and $\\omega$ such that, being $q_1,\\; q_2,\\; q_3$ the longitudinal momentum components of each of them:\n",
     "\n",
-    "> $ q_1 = \\sqrt{\\frac{2}{3}} q\\sin\\omega$\n",
-    "\n",
-    "> $ q_2 = \\sqrt{\\frac{2}{3}} q\\sin (\\omega + \\frac{2}{3}\\pi) $\n",
-    "\n",
-    "> $ q_3 = \\sqrt{\\frac{2}{3}} q\\sin (\\omega + \\frac{4}{3}\\pi)$\n",
-    "\n",
-    "> $ q = \\sqrt{q_1^2 + q_2^2 + q_3^2}$\n",
+    "$$\n",
+    "\\begin{eqnarray}\n",
+    "q_1 &=& \\sqrt{\\tfrac{2}{3}} q\\sin\\omega \\\\\n",
+    "q_2 &=& \\sqrt{\\tfrac{2}{3}} q\\sin (\\omega + \\tfrac{2}{3}\\pi) \\\\\n",
+    "q_3 &=& \\sqrt{\\tfrac{2}{3}} q\\sin (\\omega + \\tfrac{4}{3}\\pi) \\\\\n",
+    "q &=& \\sqrt{q_1^2 + q_2^2 + q_3^2}\n",
+    "\\end{eqnarray}\n",
+    "$$\n",
     "\n",
     "In a longitudinal plot the $(X,Y)$ coordinates are defined as follows:\n",
     "\n",
-    "> $ X = q\\cos\\omega $\n",
+    "$$\n",
+    "\\begin{eqnarray}\n",
+    "X &=& q\\cos\\omega \\\\\n",
+    "Y &=& q\\sin\\omega\n",
+    "\\end{eqnarray}\n",
+    "$$\n",
     "\n",
-    "> $ Y = q\\sin\\omega $\n",
-    "\n",
-    "Let's build the cartesian coordinates arrays and make the scatter plot.\n",
-    "\n",
-    "\n"
+    "Let's build the cartesian coordinates arrays and make the scatter plot."
    ]
   },
   {
@@ -196,11 +153,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q1 = pionPlusCM.p_z\n",
-    "q2 = pionMinusCM.p_z\n",
-    "q3 = protonCM.p_z\n",
-    "q = np.sqrt(q1 * q1 + q2 * q2 + q3 * q3)\n",
-    "len = q.size"
+    "q1 = pip_cm.p_z\n",
+    "q2 = pim_cm.p_z\n",
+    "q3 = proton_cm.p_z\n",
+    "q = np.sqrt(q1**2 + q2**2 + q3**2)"
    ]
   },
   {
@@ -209,62 +165,69 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = np.zeros(len)\n",
-    "X = []\n",
-    "Y = []\n",
-    "fac = np.sqrt(3.0 / 2.0)\n",
-    "for i in range(len):\n",
-    "    a[i] = fac * q1[i] / q[i]\n",
-    "    if q[i] != 0 and np.abs(a[i]) <= 1.0:\n",
-    "        omega = np.arcsin(a[i])\n",
-    "        sinOmega = a[i]\n",
-    "        cosOmega = (2 * q2[i] + q1[i]) / np.sqrt(2) / q[i]\n",
-    "        if cosOmega < 0:\n",
-    "            if sinOmega >= 0:\n",
-    "                omega = np.pi - omega\n",
-    "            else:\n",
-    "                omega -= np.pi\n",
-    "\n",
-    "        X.append(q[i] * cosOmega)\n",
-    "        Y.append(q[i] * sinOmega)"
+    "a = np.sqrt(3 / 2) * q1 / q\n",
+    "filter_ = np.abs(a) <= 1\n",
+    "sin_omega = a[filter_]\n",
+    "cos_omega = (2 * q2 + q1) / np.sqrt(2) / q\n",
+    "cos_omega = cos_omega[filter_]\n",
+    "omega = np.arcsin(sin_omega)\n",
+    "omega = np.select(\n",
+    "    [(cos_omega < 0) & (sin_omega >= 0), True],\n",
+    "    [np.pi - omega, omega - np.pi],\n",
+    ")\n",
+    "X = q[filter_] * cos_omega\n",
+    "Y = q[filter_] * sin_omega"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "q1 + q2 + q3"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "plt.hist2d(X, Y, bins=100, cmap=\"rainbow\")\n",
-    "x1, y1 = [-10, 10], [0, 0]\n",
-    "plt.plot(x1, y1, color=\"black\")\n",
+    "plt.plot([-10, 10], [0, 0], color=\"black\")\n",
     "sixty = np.pi / 3\n",
-    "x2, y2 = [-10 * np.cos(sixty), 10 * np.cos(sixty)], [\n",
-    "    10 * np.sin(sixty),\n",
-    "    -10 * np.sin(sixty),\n",
-    "]\n",
-    "plt.plot(x2, y2, color=\"black\")\n",
-    "x3, y3 = [10 * np.cos(sixty), -10 * np.cos(sixty)], [\n",
-    "    10 * np.sin(sixty),\n",
-    "    -10 * np.sin(sixty),\n",
-    "]\n",
-    "plt.plot(x3, y3, color=\"black\")"
+    "plt.plot(\n",
+    "    [-10 * np.cos(sixty), 10 * np.cos(sixty)],\n",
+    "    [10 * np.sin(sixty), -10 * np.sin(sixty)],\n",
+    "    color=\"black\",\n",
+    ")\n",
+    "plt.plot(\n",
+    "    x3=[10 * np.cos(sixty), -10 * np.cos(sixty)],\n",
+    "    y3=[10 * np.sin(sixty), -10 * np.sin(sixty)],\n",
+    "    color=\"black\",\n",
+    ")\n",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "Try with another input file (for instance the generated MonteCarlo events at 5 or 10 GeV incident momentum) and check the differences."
+    "Try with another input file (see [here](https://drive.google.com/drive/folders/1-Knh70_vLuctCkcg9oIIIIBaX2EPYkea) on Google Drive, for instance the generated MonteCarlo events at 5 or 10 GeV incident momentum) and check the differences. The whole folder can be downloaded as follows:\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "gdown.download_folder(id=\"1-Knh70_vLuctCkcg9oIIIIBaX2EPYkea\", output=\"data\", quiet=True)\n",
+    "```\n",
+    "\n",
+    "Then set `data` to for instance\n",
+    "\n",
+    "```python\n",
+    "data = pd.read_csv(\"data/FurtherFun/gammaP_5GeV_protKPlusKMinusEtamiss.csv\")\n",
+    "```\n",
+    "\n",
+    "and rerun the notebook."
    ]
   }
  ],


### PR DESCRIPTION
Major speed-ups to some notebooks by vectorising the code with NumPy so that the evaluation now takes [2m54](https://github.com/ComPWA/strong2020-salamanca/actions/runs/6132649129/job/16643747731?pr=5) instead of [12m36](https://github.com/ComPWA/strong2020-salamanca/actions/runs/6132549623/job/16643537217). Some other improvements:

* Added more subsections in Lecture 12
* Added links to used packages for more info
* Input cells for plotting are now hidden
* Construction of `pylorentz.Momentum4` has been simplified by directly building them from $(E, p_x, p_y, p_z)$
* Variable naming has been updated to follow PEP8 in more locations