### PR TITLE
DX: host GitHub Pages on fork as PR preview

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@ name: Documentation
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -11,6 +9,7 @@ on:
 
 jobs:
   doc:
+    if: github.event_name == 'push' && (github.repository != 'ComPWA/strong2020-salamanca' || github.ref_name == 'main') || github.event_name == 'pull_request'
     name: Execute and build
     runs-on: ubuntu-22.04
     steps:
@@ -44,11 +43,11 @@ jobs:
           path: ./docs/_build/html
 
   gh-pages:
+    if: github.event_name == 'push' && (github.repository != 'ComPWA/strong2020-salamanca' || github.ref_name == 'main')
     name: Upload to GitHub Pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     needs:
       - doc
     permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     name: Execute and build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -38,7 +38,7 @@ jobs:
           path: |
             ./docs/data
       - run: jupyter book build docs/ -W
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v2
         if: always()
         with:
           path: ./docs/_build/html


### PR DESCRIPTION
Currently, the documentation CI job runs only on PRs and (naturally) the build files are only hosted from the `main` branch of [ComPWA/strong2020-salamanca](https://github.com/ComPWA/strong2020-salamanca). This PR should make it possible to run the doc job on _pushes_ to your fork and then directly host the build files for the GitHub pages of your fork (you need to configure the pages [to be published from a workflow](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow) and remove the [environment restrictions](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules) so that the pages can be published from other branches than your `main` branch).

_This PR is motivated by https://github.com/ComPWA/RUB-EP1-AG/issues/78._