### PR TITLE
MAINT: update pip constraints and pre-commit

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -139,7 +139,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -138,7 +138,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.12.txt
+++ b/.constraints/py3.12.txt
@@ -138,7 +138,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -144,7 +144,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -140,7 +140,7 @@ rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
             metadata.vscode
 
   - repo: https://github.com/ComPWA/policy
-    rev: 0.3.4
+    rev: 0.3.5
     hooks:
       - id: check-dev-files
         args:
@@ -61,7 +61,7 @@ repos:
         args: [--py38-plus]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-case-conflict
       - id: check-json


### PR DESCRIPTION
This PR updates the [`pip` constraint files](https://github.com/ComPWA/update-pip-constraints?tab=readme-ov-file#update-pip-constraint-files) under the `.constraints/` directory and pre-commit hooks in [`.pre-commit-config.yaml`](https://pre-commit.com). It was created automatically by a scheduled workflow.